### PR TITLE
Remove gatsby plugin google analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -70,10 +70,17 @@ module.exports = {
         ],
       },
     },
+    // https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/
     {
-      resolve: `gatsby-plugin-google-analytics`,
+      resolve: `gatsby-plugin-google-gtag`,
       options: {
-        trackingId: config.googleAnalyticsID,
+        trackingIds: [config.googleAnalyticsID],
+        pluginConfig: {
+          // Puts tracking script in the head instead of the body
+          head: false,
+          // Setting this parameter is also optional
+          respectDNT: false,
+        },
       },
     },
   ],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-styled-components": "^1.10.0",
     "gatsby": "^2.30.3",
     "gatsby-image": "^2.0.39",
+    "gatsby-plugin-google-gtag": "^2.7.0",
     "gatsby-plugin-manifest": "^2.0.29",
     "gatsby-plugin-netlify": "^2.9.0",
     "gatsby-plugin-offline": "^2.0.25",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "babel-plugin-styled-components": "^1.10.0",
     "gatsby": "^2.30.3",
     "gatsby-image": "^2.0.39",
-    "gatsby-plugin-google-analytics": "^2.0.18",
     "gatsby-plugin-manifest": "^2.0.29",
     "gatsby-plugin-netlify": "^2.9.0",
     "gatsby-plugin-offline": "^2.0.25",

--- a/src/components/externalLink.js
+++ b/src/components/externalLink.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { OutboundLink } from 'gatsby-plugin-google-analytics';
+import { OutboundLink } from 'gatsby-plugin-google-gtag';
 
 const ExternalLink = ({ url, children, className, ...otherProps }) => (
   <OutboundLink

--- a/src/components/projects.js
+++ b/src/components/projects.js
@@ -2,7 +2,6 @@ import { Button, Section, media, mixins, theme } from '@styles';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { IconExternal, IconFolder, IconGithub, IconGooglePlay } from '@components/icons';
 import { useEffect, useRef, useState } from 'react';
-import { trackCustomEvent } from 'gatsby-plugin-google-analytics';
 
 import PropTypes from 'prop-types';
 import sr from '@utils/sr';
@@ -131,16 +130,15 @@ const Projects = ({ data }) => {
   const onShowMoreClick = e => {
     e.preventDefault();
     setShowMore(!showMore);
-    trackCustomEvent({
-      // string - required - The object that was interacted with (e.g.video)
-      category: 'Show More Projects Button',
-      // string - required - Type of interaction (e.g. 'play')
-      action: 'Click',
-      // string - optional - Useful for categorizing events (e.g. 'Spring Campaign')
-      label: 'Portfolio Click Events',
-      // number - optional - Numeric value associated with the event. (e.g. A product ID)
-      // value: 43
-    });
+    typeof window !== 'undefined' &&
+      window.gtag('event', 'click', {
+        // string - The category of the event.
+        event_category: 'Show More Projects Button',
+        // string - The label of the event.
+        event_label: 'Portfolio Click Events',
+        // number - optional - A non-negative integer that will appear as the vent value.
+        // value: 43
+      });
   };
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -6426,14 +6426,6 @@ gatsby-page-utils@^0.7.0:
     lodash "^4.17.20"
     micromatch "^4.0.2"
 
-gatsby-plugin-google-analytics@^2.0.18:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.6.0.tgz#6fd6a8bdb4eb2adc2cc88687f9fb3b334787cbe9"
-  integrity sha512-2pxd2iaJUWVIIGkP4T2PTDlmMEjnRLrP+ZXV65SpOy2Q2Od2tpiStol6B5T6iGjtKGs6ZOdk3D1gyTCvH+gpsg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    minimatch "3.0.4"
-
 gatsby-plugin-manifest@^2.0.29:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.7.0.tgz#44526226e8d0a2f80c2a81e5a5c7e9a03963a890"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6426,6 +6426,14 @@ gatsby-page-utils@^0.7.0:
     lodash "^4.17.20"
     micromatch "^4.0.2"
 
+gatsby-plugin-google-gtag@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-2.7.0.tgz#322f1d7cdefa4e9c45a77ad70e569685369944d4"
+  integrity sha512-9BvJRlHHknQaoOsPiZQJrZ3IuBP1iuj701kFIYzUQV0BA/3sDDEn2MeiAsyjguhR8+bJ6bYZZXHjX/UAEhD8Lw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    minimatch "^3.0.4"
+
 gatsby-plugin-manifest@^2.0.29:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.7.0.tgz#44526226e8d0a2f80c2a81e5a5c7e9a03963a890"


### PR DESCRIPTION
An [upgrade note](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/#upgrade-note) was added in [gatsby-plugin-google-analytics](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics).

This PR removes [gatsby-plugin-google-analytics](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics) & replaces it with [gatsby-plugin-google-gtag](https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/)

![image](https://user-images.githubusercontent.com/21218732/105615481-11b03d00-5df7-11eb-9a19-73b42d3cffc3.png)
