### PR TITLE
Use Netlify proxy & Add Splitbee events 

### DIFF
--- a/src/components/about.js
+++ b/src/components/about.js
@@ -160,7 +160,7 @@ const About = ({ data }) => {
           </SkillsContainer>
         </ContentContainer>
         <PicContainer>
-          <AvatarContainer url={github}>
+          <AvatarContainer url={github} eventType="Github">
             <Avatar fluid={avatar.childImageSharp.fluid} alt="Avatar" />
           </AvatarContainer>
         </PicContainer>

--- a/src/components/contact.js
+++ b/src/components/contact.js
@@ -58,7 +58,7 @@ const Contact = ({ data }) => {
 
       <div dangerouslySetInnerHTML={{ __html: html }} />
 
-      <EmailLink url="mailto:hello@ayushgupta.tech" data-splitbee-event="Say Hello">
+      <EmailLink url="mailto:hello@ayushgupta.tech" eventName="Mail" eventType="Hello">
         Say Hello{' '}
         <span role="img" aria-label="wave">
           👋🏻

--- a/src/components/email.js
+++ b/src/components/email.js
@@ -61,7 +61,9 @@ const Email = () => {
         {isMounted && (
           <CSSTransition timeout={3000} classNames="fade">
             <EmailLinkWrapper>
-              <EmailLink url={`mailto:${email}`}>{email}</EmailLink>
+              <EmailLink url={`mailto:${email}`} eventName="Mail" eventType="Hello">
+                {email}
+              </EmailLink>
             </EmailLinkWrapper>
           </CSSTransition>
         )}

--- a/src/components/externalLink.js
+++ b/src/components/externalLink.js
@@ -2,12 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { OutboundLink } from 'gatsby-plugin-google-gtag';
 
-const ExternalLink = ({ url, children, className, ...otherProps }) => (
+const ExternalLink = ({
+  url,
+  children,
+  className,
+  eventName = 'External Link',
+  eventType = '',
+  ...otherProps
+}) => (
   <OutboundLink
     className={className}
     href={url}
     target="_blank"
     rel="nofollow noopener noreferrer"
+    data-splitbee-event={eventName}
+    data-splitbee-event-type={eventType ? eventType : url}
     {...otherProps}>
     {children}
   </OutboundLink>
@@ -17,6 +26,8 @@ ExternalLink.propTypes = {
   url: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  eventName: PropTypes.string,
+  eventType: PropTypes.string,
   otherProps: PropTypes.node,
 };
 

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -64,7 +64,7 @@ const Footer = () => (
         {socialMedia &&
           socialMedia.map(({ name, url }, i) => (
             <li key={i}>
-              <SocialLink url={url} aria-label={name}>
+              <SocialLink url={url} aria-label={name} eventType={name}>
                 {name === 'Github' ? (
                   <IconGithub />
                 ) : name === 'Linkedin' ? (
@@ -86,7 +86,7 @@ const Footer = () => (
       </SocialItemList>
     </SocialContainer>
     <Copy>
-      <GithubLink url="https://github.com/gupta-ji6">
+      <GithubLink url="https://github.com/gupta-ji6" eventType="Github">
         <small>
           Customized with{' '}
           <span role="img" aria-label="Coffee">

--- a/src/components/head.js
+++ b/src/components/head.js
@@ -70,7 +70,7 @@ const Head = ({ metadata }) => (
     <meta name="msapplication-TileImage" content={msIcon144x144} />
     <meta name="theme-color" content={config.navyColor} />
 
-    <script async src="https://cdn.splitbee.io/sb.js"></script>
+    <script async data-api="/_hive" src="/bee.js"></script>
   </Helmet>
 );
 

--- a/src/components/hero.js
+++ b/src/components/hero.js
@@ -124,7 +124,12 @@ const Hero = ({ data }) => {
     Object.keys(track).length !== 0 ? (
       <NowPlayingTrack style={{ transitionDelay: '500ms' }}>
         <TrackCopy>{`${trackCopy} `}</TrackCopy>
-        <ExternalLink url={track.external_urls.spotify}>{track.name}</ExternalLink>
+        <ExternalLink
+          url={track.external_urls.spotify}
+          eventName="Spotify"
+          eventType="Open Spotify Link">
+          {track.name}
+        </ExternalLink>
         <span>{` at the moment.`}</span>
       </NowPlayingTrack>
     ) : null;
@@ -134,7 +139,7 @@ const Hero = ({ data }) => {
       {/* <ResumeLink href="/resume.pdf" target="_blank" rel="nofollow noopener noreferrer">
         View Resume
       </ResumeLink> */}
-      <EmailLink url="mailto:hire@ayushgupta.tech" data-splitbee-event="Hire Me">
+      <EmailLink url="mailto:hire@ayushgupta.tech" eventName="Hire Me">
         Hire Me {/* <span role="img" aria-label="man technologist">
           👨🏻‍💻
         </span> */}

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -109,7 +109,7 @@ const Menu = ({ menuOpen, toggleMenu }) => {
                 </NavListItem>
               ))}
           </NavList>
-          <ResumeLink url="/resume" data-splitbee-event="View Resume">
+          <ResumeLink url="/resume" eventName="View Resume">
             Resume
           </ResumeLink>
         </NavLinks>

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -298,7 +298,7 @@ class Nav extends Component {
               {isMounted && (
                 <CSSTransition classNames={fadeDownClass} timeout={timeout}>
                   <div style={{ transitionDelay: `${isHome ? navLinks.length * 100 : 0}ms` }}>
-                    <StyledResumeButton url="/resume" data-splitbee-event="View Resume">
+                    <StyledResumeButton url="/resume" eventName="View Resume">
                       Resume
                     </StyledResumeButton>
                   </div>

--- a/src/components/now-palying.js
+++ b/src/components/now-palying.js
@@ -239,7 +239,10 @@ const NowPlaying = () => {
     <div>
       <TrackContext>{fetchNowPlayingCopy()}</TrackContext>
       <NowPlayingWidget>
-        <ExternalLink url={track?.external_urls?.spotify || SPOTIFY_PROFILE}>
+        <ExternalLink
+          url={track?.external_urls?.spotify || SPOTIFY_PROFILE}
+          eventName="Spotify"
+          eventType="Open Spotify Link">
           <AlbumImage
             src={track?.album?.images[0].url || 'https://source.unsplash.com/128x128/?music'}
             width="48"
@@ -248,7 +251,10 @@ const NowPlaying = () => {
             alt="music"
           />
         </ExternalLink>
-        <ExternalLink url={track?.external_urls?.spotify || SPOTIFY_PROFILE}>
+        <ExternalLink
+          url={track?.external_urls?.spotify || SPOTIFY_PROFILE}
+          eventName="Spotify"
+          eventType="Open Spotify Link">
           <TrackInfo>
             <TrackName>{track?.name || 'Not Playing'}</TrackName>
             <AlbumName>{track?.album?.name || 'View Spotify Profile'}</AlbumName>
@@ -258,7 +264,8 @@ const NowPlaying = () => {
           <button
             onClick={toggleAudio}
             disabled={!isAyushListeningToAnything}
-            data-splitbee-event="Play Spotify Song Preview">
+            eventName="Spotify"
+            eventType="Play Spotify Song Preview">
             {isAyushListeningToAnything && track?.preview_url !== null ? (
               isPlaying ? (
                 <IconPause />

--- a/src/components/projects.js
+++ b/src/components/projects.js
@@ -198,7 +198,8 @@ const Projects = ({ data }) => {
 
       <ShowMoreButton
         onClick={e => onShowMoreClick(e)}
-        data-splitbee-event={`Show ${showMore ? 'Fewer' : 'More'} Projects`}>
+        data-splitbee-event="Show Projects"
+        data-splitbee-event-type={showMore ? 'Fewer' : 'More'}>
         {`Show ${showMore ? 'Fewer' : 'More'} Projects`}
       </ShowMoreButton>
     </ProjectsContainer>

--- a/src/components/social.js
+++ b/src/components/social.js
@@ -63,7 +63,7 @@ const Social = () => {
               {socialMedia &&
                 socialMedia.map(({ url, name }, i) => (
                   <SocialItem key={i}>
-                    <SocialLink url={url} aria-label={name}>
+                    <SocialLink url={url} aria-label={name} eventType={name}>
                       <FormattedIcon name={name} />
                     </SocialLink>
                   </SocialItem>

--- a/src/pages/uses.js
+++ b/src/pages/uses.js
@@ -190,7 +190,10 @@ const UsesPage = ({ data, location }) => {
           <h2>Have more questions?</h2>
           <p>
             Feel free to ask away on{' '}
-            <ExternalLink url="https://twitter.com/_guptaji_">twitter</ExternalLink>.
+            <ExternalLink url="https://twitter.com/_guptaji_" eventType="Twitter">
+              twitter
+            </ExternalLink>
+            .
           </p>
           <small>Last Updated: November, 2020</small>
         </MoreQuestionsSection>

--- a/static/_redirects
+++ b/static/_redirects
@@ -19,3 +19,8 @@
 
 /grid-flex           https://medium.com/youstart-labs/beginners-guide-to-choose-between-css-grid-and-flexbox-783005dd2412
 /gif                 https://medium.com/youstart-labs/how-to-play-gif-in-your-terminal-d7657578e717
+
+# Splitbee Redirects - https://splitbee.io/docs/netlify-proxy
+
+/bee.js  https://cdn.splitbee.io/sb.js  200
+/_hive/*  https://hive.splitbee.io/:splat  200


### PR DESCRIPTION
Extension of #22 

- Use Netlify redirects to [proxy](https://splitbee.io/docs/netlify-proxy) all analytics traffic through my own domain. This will reduce DNS lookups, as well as prevent Adblockers from blocking requests.
- Add [event tracking](https://splitbee.io/docs/track-events)
- Add [Telegram notification using Automation](https://splitbee.io/docs/telegram-automations)

