### PR TITLE
fix: production stability — remove dead deps, harden Spotify & Hasura

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -7,7 +7,6 @@
 // You can delete this file if you're not using it
 
 const React = require('react');
-const splitbee = require('@splitbee/web');
 const { toast } = require('react-hot-toast');
 const theme = require('./src/styles/theme');
 
@@ -25,15 +24,7 @@ const updateButtonStyles = {
 };
 
 // Called when the Gatsby browser runtime first starts
-exports.onClientEntry = () => {
-  if (process.env.NODE_ENV === 'production') {
-    splitbee.default.init({
-      disableCookie: true, // will disable the cookie usage
-      scriptUrl: 'https://ayushgupta.tech/bee.js',
-      apiUrl: 'https://ayushgupta.tech/_hive',
-    });
-  }
-};
+exports.onClientEntry = () => {};
 
 // Reference - https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#onServiceWorkerUpdateReady
 // Also see - https://github.com/gatsbyjs/gatsby/issues/9087#issuecomment-723294431

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,12 @@
+const path = require('path');
+
+// Load project-root `.env` before Gatsby builds webpack `GATSBY_*` replacements (avoids `undefined` in the client when the shell cwd or env ordering differs).
+try {
+  require('dotenv').config({ path: path.join(__dirname, '.env') });
+} catch {
+  /* dotenv may be unavailable in minimal installs */
+}
+
 const config = require('./src/config');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@github/time-elements": "3.1.2",
-    "@splitbee/web": "0.2.4",
     "animejs": "3.0.1",
     "babel-plugin-styled-components": "1.13.2",
     "gatsby": "3.14.x",

--- a/src/components/externalLink.js
+++ b/src/components/externalLink.js
@@ -6,28 +6,31 @@ const ExternalLink = ({
   url,
   children,
   className = '',
-  eventName = 'External Link',
-  eventType = '',
   ...otherProps
-}) => (
-  <OutboundLink
-    className={className}
-    href={url}
-    target="_blank"
-    rel="nofollow noopener noreferrer"
-    data-splitbee-event={eventName}
-    data-splitbee-event-type={eventType ? eventType : url}
-    {...otherProps}>
-    {children}
-  </OutboundLink>
-);
+}) => {
+  if (url == null || url === '') {
+    return (
+      <span className={className} {...otherProps}>
+        {children}
+      </span>
+    );
+  }
+  return (
+    <OutboundLink
+      className={className}
+      href={url}
+      target="_blank"
+      rel="nofollow noopener noreferrer"
+      {...otherProps}>
+      {children}
+    </OutboundLink>
+  );
+};
 
 ExternalLink.propTypes = {
-  url: PropTypes.string.isRequired,
+  url: PropTypes.string,
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
-  eventName: PropTypes.string,
-  eventType: PropTypes.string,
   otherProps: PropTypes.node,
 };
 

--- a/src/components/nav.js
+++ b/src/components/nav.js
@@ -8,12 +8,12 @@ import ExternalLink from './externalLink';
 import { Menu } from '@components';
 import { IconLogo } from '@components/icons';
 import { useScrollDirection } from '@hooks';
-import { navLinks } from '@config';
+import { navLinks, loaderDelay } from '@config';
 import { mixins, theme } from '@styles';
 
 // --------------------------- CONSTANTS ------------------------------------------
 
-const { colors, fontSizes, fonts, loaderDelay } = theme;
+const { colors, fontSizes, fonts } = theme;
 
 export const navLinkRedirection = (url, name) => {
   switch (name) {

--- a/src/components/sections/hero.js
+++ b/src/components/sections/hero.js
@@ -14,6 +14,9 @@ import ExternalLink from '../externalLink';
 
 const { colors, fontSizes, fonts } = theme;
 
+const SPOTIFY_PROFILE_FALLBACK =
+  'https://open.spotify.com/user/31yuvamoxkbmkpvhpunh6xwoshii';
+
 // --------------------------- STYLED COMPONENTS -----------------------------------
 
 const HeroContainer = styled(Section)`
@@ -150,7 +153,7 @@ const Hero = () => {
       <NowPlayingTrack>
         <TrackCopy>{`${trackCopy} `}</TrackCopy>
         <ExternalLink
-          url={nowPlayingTrack.external_urls.spotify}
+          url={nowPlayingTrack.external_urls?.spotify || SPOTIFY_PROFILE_FALLBACK}
           eventName="Spotify"
           eventType={`Hero - ${nowPlayingTrack.name}`}>
           {nowPlayingTrack.name}

--- a/src/hooks/useComments.js
+++ b/src/hooks/useComments.js
@@ -53,6 +53,10 @@ export const useComments = (hasuraUrl, postId, config) => {
   const [loading, setLoading] = useState(false);
 
   const fetchComments = () => {
+    if (!hasuraUrl) {
+      setLoading(false);
+      return;
+    }
     setLoading(true);
     fetch(hasuraUrl, {
       method: 'POST',
@@ -103,6 +107,9 @@ export const useComments = (hasuraUrl, postId, config) => {
   ]);
 
   const addComment = ({ content, author }) => {
+    if (!hasuraUrl) {
+      return;
+    }
     const createdAt = new Date().toDateString();
     const newComment = {
       author,

--- a/src/hooks/useRecentlyPlayedTracks.js
+++ b/src/hooks/useRecentlyPlayedTracks.js
@@ -18,9 +18,8 @@ function useRecentlyPlayedTracks(limit = 20) {
     setRecentTracksLoading(true);
     const tracks = await fetchCurrentUsersRecentlyPlayed(limit);
     if (tracks !== undefined) {
-      const uniqueRecentTracks = uniqBy(tracks?.items, function (e) {
-        return e.track.id;
-      });
+      const itemsWithTrack = (tracks?.items || []).filter(e => e?.track?.id != null);
+      const uniqueRecentTracks = uniqBy(itemsWithTrack, e => e.track.id);
       setRecentlyPlayedTracks(uniqueRecentTracks);
       setRecentTracksLoading(false);
       setRecentTracksError(null);

--- a/src/pages/music.js
+++ b/src/pages/music.js
@@ -17,6 +17,7 @@ import {
 import { theme, mixins, media } from '@styles';
 import { siteUrl, srConfig } from '@config';
 import sr from '@utils/sr';
+import { pickSpotifyCoverImage } from '@utils/spotify';
 import ogImage from '@images/og-music.png';
 import { IconCheck } from '@components/icons';
 
@@ -336,19 +337,20 @@ const MusicPage = ({ location }) => {
         <Fragment>
           {topTracks.map(track => {
             const { album, artists, external_urls, name, id } = track;
-            const trackArtists = artists.map(artist => artist.name);
+            const trackArtists = (artists || []).map(artist => artist.name);
+            const cover = pickSpotifyCoverImage(album?.images);
             return (
               <TrackItem key={id}>
                 <StyledAlbumCover
-                  src={album.images[1].url}
-                  height={album.images[1].height}
-                  width={album.images[1].width}
-                  alt={`${album.name}'s album cover`}
+                  src={cover?.url}
+                  height={cover?.height}
+                  width={cover?.width}
+                  alt={`${album?.name ?? name}'s album cover`}
                   loading="lazy"
                 />
                 <TrackInfoContainer>
                   <ExternalLink
-                    url={external_urls.spotify}
+                    url={external_urls?.spotify}
                     eventName="Spotify"
                     eventType={`Top Tracks - ${name}`}>
                     {name}
@@ -379,7 +381,9 @@ const MusicPage = ({ location }) => {
         </RefetchContainer>
       );
     } else if (Object.keys(ayushFavouritePlaylist).length > 0) {
-      const { name, images, id, owner, tracks, external_urls } = ayushFavouritePlaylist;
+      const { name, images, id, owner, tracks, items, external_urls } = ayushFavouritePlaylist;
+      // Feb 2026 Dev Mode: playlist `tracks` summary → `items` (see Spotify migration guide).
+      const playlistTrackTotal = items?.total ?? tracks?.total;
       return (
         <TrackItem key={id}>
           <StyledAlbumCover
@@ -399,7 +403,9 @@ const MusicPage = ({ location }) => {
               </ExternalLink>
               <span> by {owner?.display_name}</span>
             </div>
-            <Artists>{tracks?.total} tracks</Artists>
+            <Artists>
+              {typeof playlistTrackTotal === 'number' ? `${playlistTrackTotal} tracks` : ''}
+            </Artists>
           </TrackInfoContainer>
         </TrackItem>
       );
@@ -426,23 +432,24 @@ const MusicPage = ({ location }) => {
         <Fragment>
           {topArtists.map(artist => {
             const { external_urls, name, id, images, genres } = artist;
+            const cover = pickSpotifyCoverImage(images);
             return (
               <TrackItem key={id}>
                 <StyledAlbumCover
-                  src={images[1].url}
-                  height={images[1].height}
-                  width={images[1].width}
+                  src={cover?.url}
+                  height={cover?.height}
+                  width={cover?.width}
                   alt={`${name}'s picture`}
                   loading="lazy"
                 />
                 <TrackInfoContainer>
                   <ExternalLink
-                    url={external_urls.spotify}
+                    url={external_urls?.spotify}
                     eventName="Spotify"
                     eventType={`Top Artists - ${name}`}>
                     {name}
                   </ExternalLink>
-                  <Artists>{genres.join(', ')}</Artists>
+                  <Artists>{(genres || []).join(', ')}</Artists>
                 </TrackInfoContainer>
               </TrackItem>
             );
@@ -473,19 +480,20 @@ const MusicPage = ({ location }) => {
           {recentlyPlayedTracks.map(trackData => {
             const { track } = trackData;
             const { album, artists, external_urls, name, id } = track;
-            const trackArtists = artists.map(artist => artist.name);
+            const trackArtists = (artists || []).map(artist => artist.name);
+            const cover = pickSpotifyCoverImage(album?.images);
             return (
               <TrackItem key={id}>
                 <StyledAlbumCover
-                  src={album.images[1].url}
-                  height={album.images[1].height}
-                  width={album.images[1].width}
-                  alt={`${album.name}'s album cover`}
+                  src={cover?.url}
+                  height={cover?.height}
+                  width={cover?.width}
+                  alt={`${album?.name ?? name}'s album cover`}
                   loading="lazy"
                 />
                 <TrackInfoContainer>
                   <ExternalLink
-                    url={external_urls.spotify}
+                    url={external_urls?.spotify}
                     eventName="Spotify"
                     eventType={`Recently Played - ${name}`}>
                     {name}
@@ -521,19 +529,20 @@ const MusicPage = ({ location }) => {
           {recentlySavedTracks.map(trackData => {
             const { track } = trackData;
             const { album, artists, external_urls, name, id } = track;
-            const trackArtists = artists.map(artist => artist.name);
+            const trackArtists = (artists || []).map(artist => artist.name);
+            const cover = pickSpotifyCoverImage(album?.images);
             return (
               <TrackItem key={id}>
                 <StyledAlbumCover
-                  src={album.images[1].url}
-                  height={album.images[1].height}
-                  width={album.images[1].width}
-                  alt={`${album.name}'s album cover`}
+                  src={cover?.url}
+                  height={cover?.height}
+                  width={cover?.width}
+                  alt={`${album?.name ?? name}'s album cover`}
                   loading="lazy"
                 />
                 <TrackInfoContainer>
                   <ExternalLink
-                    url={external_urls.spotify}
+                    url={external_urls?.spotify}
                     eventName="Spotify"
                     eventType={`Recently Saved - ${name}`}>
                     {name}
@@ -567,34 +576,32 @@ const MusicPage = ({ location }) => {
       return (
         <Fragment>
           {userPlaylists.map(playlistData => {
-            const {
-              name,
-              images,
-              id,
-              owner: { display_name },
-              tracks: { total },
-              external_urls,
-            } = playlistData;
+            const { name, images, id, owner, tracks, external_urls } = playlistData;
+            const display_name = owner?.display_name;
+            const total = tracks?.total;
+            const cover = pickSpotifyCoverImage(images);
             return (
               <TrackItem key={id}>
                 <StyledAlbumCover
-                  src={images[0].url}
-                  height={images[0].height}
-                  width={images[0].width}
+                  src={cover?.url}
+                  height={cover?.height}
+                  width={cover?.width}
                   alt={`${name}'s playlist cover`}
                   loading="lazy"
                 />
                 <TrackInfoContainer>
                   <div>
                     <ExternalLink
-                      url={external_urls.spotify}
+                      url={external_urls?.spotify}
                       eventName="Spotify"
                       eventType={`Recently Saved Playlist - ${name}`}>
                       {name}
                     </ExternalLink>
                     <span> by {display_name}</span>
                   </div>
-                  <Artists>{total} tracks</Artists>
+                  <Artists>
+                    {typeof total === 'number' ? `${total} tracks` : ''}
+                  </Artists>
                 </TrackInfoContainer>
               </TrackItem>
             );

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -60,8 +60,6 @@ const theme = {
 
   gradient: `linear-gradient(0.4turn, #64d6ff, #64ffda)`,
 
-  loaderDelay: `5`,
-
   hamburgerWidth: '30px',
   hamBefore: `top 0.1s ease-in 0.25s, opacity 0.1s ease-in`,
   hamBeforeActive: `top 0.1s ease-out, opacity 0.1s ease-out 0.12s`,

--- a/src/utils/spotify.js
+++ b/src/utils/spotify.js
@@ -9,15 +9,17 @@ const CURRENT_USER_SAVED_TRACKS_URL = 'https://api.spotify.com/v1/me/tracks';
 const CURRENT_USER_TOP_ARTISTS_TRACKS_URL = 'https://api.spotify.com/v1/me/top';
 const CURRENT_USER_PROFILE_URL = 'https://api.spotify.com/v1/me';
 
-let basic;
-if (typeof window !== 'undefined') {
-  basic = btoa(
-    `${process.env.GATSBY_SPOTIFY_CLIENT_ID}:${process.env.GATSBY_SPOTIFY_CLIENT_SECRET}`,
-  );
-} else {
-  basic = Buffer.from(
-    `${process.env.GATSBY_SPOTIFY_CLIENT_ID}:${process.env.GATSBY_SPOTIFY_CLIENT_SECRET}`,
-  ).toString('base64');
+function spotifyBasicAuthHeader() {
+  const id = process.env.GATSBY_SPOTIFY_CLIENT_ID;
+  const secret = process.env.GATSBY_SPOTIFY_CLIENT_SECRET;
+  if (!id || !secret) {
+    return null;
+  }
+  const pair = `${id}:${secret}`;
+  if (typeof window !== 'undefined') {
+    return btoa(pair);
+  }
+  return Buffer.from(pair).toString('base64');
 }
 
 // =============================== FUNCTIONS ===========================================================
@@ -28,9 +30,18 @@ if (typeof window !== 'undefined') {
  * @see {@link https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow}
  */
 export const getAccessToken = async () => {
+  const refresh = process.env.GATSBY_SPOTIFY_REFRESH_TOKEN;
+  const basic = spotifyBasicAuthHeader();
+  if (!basic || !refresh) {
+    console.error(
+      '[Spotify] Missing env: set GATSBY_SPOTIFY_CLIENT_ID, GATSBY_SPOTIFY_CLIENT_SECRET, and GATSBY_SPOTIFY_REFRESH_TOKEN in a project-root .env file (Gatsby only exposes vars prefixed with GATSBY_), then restart `gatsby develop`.',
+    );
+    return {};
+  }
+
   const urlencoded = new URLSearchParams();
   urlencoded.append('grant_type', 'refresh_token');
-  urlencoded.append('refresh_token', process.env.GATSBY_SPOTIFY_REFRESH_TOKEN);
+  urlencoded.append('refresh_token', refresh);
 
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
@@ -357,4 +368,16 @@ export const fetchCurrentUserProfile = async () => {
   } catch (error) {
     console.error(error);
   }
+};
+
+/**
+ * Spotify returns 0–N images; index 1 is often “medium” but may be missing.
+ * @param {Array<{ url: string; height?: number; width?: number }>|undefined} images
+ * @returns {{ url: string; height?: number; width?: number }|null}
+ */
+export const pickSpotifyCoverImage = images => {
+  if (!Array.isArray(images) || images.length === 0) {
+    return null;
+  }
+  return images[1] ?? images[0] ?? null;
 };

--- a/static/_redirects
+++ b/static/_redirects
@@ -24,11 +24,5 @@
 /grid-flex           https://medium.com/youstart-labs/beginners-guide-to-choose-between-css-grid-and-flexbox-783005dd2412
 /gif                 https://medium.com/youstart-labs/how-to-play-gif-in-your-terminal-d7657578e717
 
-# Splitbee Redirects - https://splitbee.io/docs/netlify-proxy
-
-/bee.js  https://cdn.splitbee.io/sb.js  200
-/_hive/*  https://hive.splitbee.io/:splat  200
-/analytics https://app.splitbee.io/public/ayushgupta.tech 
-
 # Others
 /ch-session https://www.clubhouse.com/event/mZgd8KZw

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,11 +1868,6 @@
     escape-string-regexp "^2.0.0"
     lodash.deburr "^4.1.0"
 
-"@splitbee/web@0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@splitbee/web/-/web-0.2.4.tgz#173ffab42a9c4d22874d82cd580d2c114480b93f"
-  integrity sha512-LMXnN5X/jen4ssBZ8ULXckQgJVvv8Ox2brcK7g2aLrok8ISzO76+DC0b6Cierk8oIXcx/+aflbVuBaKKFqyBCg==
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"


### PR DESCRIPTION
## Summary

Production has been breaking due to several issues accumulated over time. This PR addresses all of them:

- **Remove Splitbee**: The analytics service was discontinued. The `@splitbee/web` import, `init()` call, Netlify proxy redirects, and `data-splitbee-*` props on `ExternalLink` were all pointing at dead endpoints, potentially breaking client hydration.
- **Harden Spotify integration**: `btoa("undefined:undefined")` when env vars are missing, crashes from assuming `album.images[1]` always exists, unguarded `external_urls.spotify` access, and null tracks in `useRecentlyPlayedTracks` — all fixed with proper guards, optional chaining, and a `pickSpotifyCoverImage` helper.
- **Fix nav `loaderDelay`**: Was being destructured from `theme` (string `"5"`) instead of imported from `@config` (number). Removed the stale `theme.loaderDelay` entry.
- **Guard Hasura/comments**: `useComments` now skips fetch/addComment when `hasuraUrl` is falsy, so a shut-down Railway backend doesn't fire failing requests. Also loads `.env` via `dotenv` in `gatsby-config.js` for local builds.

## Test plan

- [x] Local `gatsby develop` runs without errors
- [x] Verify Netlify deploy succeeds from this branch
- [x] Hard refresh / incognito on prod — confirm no console errors
- [x] `/music` page loads and renders Spotify data
- [x] Comments section degrades gracefully (no network errors to dead Hasura URL)

Made with [Cursor](https://cursor.com)