### PR TITLE
fix: harden Spotify failure handling

### DIFF
--- a/netlify/functions/spotify.cjs
+++ b/netlify/functions/spotify.cjs
@@ -7,6 +7,16 @@ const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
 // instead of hitting Spotify's token endpoint on every request.
 let cachedToken = { value: null, expiresAt: 0 };
 
+class SpotifyAuthorizationError extends Error {}
+
+async function isInvalidGrant(response) {
+  const data = await response.json().catch(() => null);
+
+  return (
+    typeof data === 'object' && data !== null && data.error === 'invalid_grant'
+  );
+}
+
 async function getAccessToken() {
   if (cachedToken.value && Date.now() < cachedToken.expiresAt) {
     return cachedToken.value;
@@ -34,6 +44,12 @@ async function getAccessToken() {
     },
     body,
   });
+
+  if (!response.ok && (await isInvalidGrant(response))) {
+    throw new SpotifyAuthorizationError(
+      'Spotify authorization requires reauthentication',
+    );
+  }
 
   if (!response.ok) {
     throw new Error(`Token refresh failed: ${response.status}`);
@@ -97,18 +113,30 @@ exports.handler = async (event) => {
   }
 
   if (event.httpMethod !== 'GET') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) };
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
   }
 
   const params = event.queryStringParameters || {};
   const path = params.path;
 
   if (!path) {
-    return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing ?path= parameter' }) };
+    return {
+      statusCode: 400,
+      headers,
+      body: JSON.stringify({ error: 'Missing ?path= parameter' }),
+    };
   }
 
   if (!isAllowedPath(path)) {
-    return { statusCode: 403, headers, body: JSON.stringify({ error: 'Path not allowed' }) };
+    return {
+      statusCode: 403,
+      headers,
+      body: JSON.stringify({ error: 'Path not allowed' }),
+    };
   }
 
   // Build upstream query string from all params except "path"
@@ -154,10 +182,16 @@ exports.handler = async (event) => {
       '[spotify proxy]',
       err instanceof Error ? err.message : String(err),
     );
+    const requiresReauthorization = err instanceof SpotifyAuthorizationError;
+
     return {
-      statusCode: 502,
+      statusCode: requiresReauthorization ? 503 : 502,
       headers,
-      body: JSON.stringify({ error: 'Failed to proxy Spotify request' }),
+      body: JSON.stringify({
+        error: requiresReauthorization
+          ? 'reauthorization_required'
+          : 'Failed to proxy Spotify request',
+      }),
     };
   }
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "npm run dev --",
+    "test": "node --test test/spotify-proxy.test.cjs",
     "check": "astro check",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"astro.config.mjs\" \"eslint.config.mjs\" \"prettier.config.js\"",
     "format": "prettier --write \"src/**/*.{astro,ts,tsx,js,jsx,md,mdx,css}\"",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "npm run dev --",
-    "test": "node --test test/spotify-proxy.test.cjs",
+    "test": "node --experimental-strip-types --test test/spotify-proxy.test.cjs test/spotify-client.test.mjs",
     "check": "astro check",
     "lint": "eslint \"src/**/*.{js,jsx,ts,tsx,astro}\" \"astro.config.mjs\" \"eslint.config.mjs\" \"prettier.config.js\"",
     "format": "prettier --write \"src/**/*.{astro,ts,tsx,js,jsx,md,mdx,css}\"",

--- a/src/components/HeroNowPlaying.tsx
+++ b/src/components/HeroNowPlaying.tsx
@@ -12,7 +12,8 @@ interface HeroNowPlayingProps {
 }
 
 export default function HeroNowPlaying({ introSeed = 0 }: HeroNowPlayingProps) {
-  const { data: track } = useNowPlayingTrack();
+  const query = useNowPlayingTrack();
+  const track = query.kind === 'success' ? query.data : null;
   const intro = useMemo(
     () => itemFromSeed(PLAYING_INTROS, introSeed),
     [introSeed],

--- a/src/components/music/MusicExperience.tsx
+++ b/src/components/music/MusicExperience.tsx
@@ -15,14 +15,13 @@ import {
   useSavedTracks,
   useTopSpotifyItems,
   useUserPlaylists,
+  type SpotifyResourceState,
 } from '@hooks/useSpotify';
 import {
   getPlaylistTrackTotal,
   pickSpotifyCoverImage,
   type SpotifyArtist,
   type SpotifyPlaylist,
-  type SpotifyRecentlyPlayedItem,
-  type SpotifySavedTrackItem,
   type SpotifyTrack,
 } from '@utils/spotify';
 
@@ -31,11 +30,6 @@ import NowPlayingWidget from './NowPlayingWidget';
 import './music.css';
 
 type SpotifyTimeRange = 'short_term' | 'medium_term' | 'long_term';
-
-interface QueryState<T> {
-  data: T;
-  loading: boolean;
-}
 
 interface DisclosureSectionProps {
   children: ReactNode;
@@ -140,25 +134,29 @@ function ResourceState<T>({
   emptyLabel,
   loadingLabel,
   query,
+  unavailableLabel,
   children,
 }: {
   children: (_data: T) => ReactNode;
   emptyLabel: string;
   loadingLabel: string;
-  query: QueryState<T>;
+  query: SpotifyResourceState<T>;
+  unavailableLabel: string;
 }) {
-  if (query.loading) {
-    return <div className="music-feedback">{loadingLabel}</div>;
+  switch (query.kind) {
+    case 'loading':
+      return <div className="music-feedback">{loadingLabel}</div>;
+    case 'empty':
+      return <div className="music-feedback">{emptyLabel}</div>;
+    case 'unavailable':
+      return <div className="music-feedback">{unavailableLabel}</div>;
+    case 'success':
+      return <>{children(query.data)}</>;
+    default: {
+      const _exhaustive: never = query;
+      return _exhaustive;
+    }
   }
-
-  if (
-    query.data == null ||
-    (Array.isArray(query.data) && query.data.length === 0)
-  ) {
-    return <div className="music-feedback">{emptyLabel}</div>;
-  }
-
-  return <>{children(query.data)}</>;
 }
 
 function MusicRow({
@@ -282,9 +280,10 @@ function TopTracksPanel({ range }: { range: SpotifyTimeRange }) {
 
   return (
     <ResourceState
-      query={query as QueryState<SpotifyTrack[]>}
+      query={query}
       loadingLabel="Loading Ayush's top tracks..."
       emptyLabel="No top tracks are available right now."
+      unavailableLabel="Top tracks are unavailable right now."
     >
       {(tracks) => <TrackList prefix="top-track" tracks={tracks} />}
     </ResourceState>
@@ -296,9 +295,10 @@ function FavouritePlaylistPanel() {
 
   return (
     <ResourceState
-      query={query as QueryState<SpotifyPlaylist | null>}
+      query={query}
       loadingLabel="Loading favourite playlist..."
-      emptyLabel="Favourite playlist is unavailable right now."
+      emptyLabel="No favourite playlist is available right now."
+      unavailableLabel="Favourite playlist is unavailable right now."
     >
       {(playlist) => (
         <PlaylistList
@@ -315,9 +315,10 @@ function RecentlyPlayedPanel() {
 
   return (
     <ResourceState
-      query={query as QueryState<SpotifyRecentlyPlayedItem[]>}
+      query={query}
       loadingLabel="Loading recently played tracks..."
       emptyLabel="No recent listening history is available right now."
+      unavailableLabel="Recently played tracks are unavailable right now."
     >
       {(items) => (
         <TrackList
@@ -336,9 +337,10 @@ function SavedTracksPanel() {
 
   return (
     <ResourceState
-      query={query as QueryState<SpotifySavedTrackItem[]>}
+      query={query}
       loadingLabel="Loading recently saved tracks..."
       emptyLabel="No recently saved tracks are available right now."
+      unavailableLabel="Saved tracks are unavailable right now."
     >
       {(items) => (
         <TrackList
@@ -357,9 +359,10 @@ function TopArtistsPanel({ range }: { range: SpotifyTimeRange }) {
 
   return (
     <ResourceState
-      query={query as QueryState<SpotifyArtist[]>}
+      query={query}
       loadingLabel="Loading Ayush's top artists..."
       emptyLabel="No top artists are available right now."
+      unavailableLabel="Top artists are unavailable right now."
     >
       {(artists) => <ArtistList artists={artists} />}
     </ResourceState>
@@ -371,9 +374,10 @@ function SavedPlaylistsPanel() {
 
   return (
     <ResourceState
-      query={query as QueryState<SpotifyPlaylist[]>}
+      query={query}
       loadingLabel="Loading saved playlists..."
       emptyLabel="No saved playlists are available right now."
+      unavailableLabel="Saved playlists are unavailable right now."
     >
       {(playlists) => (
         <PlaylistList prefix="saved-playlist" playlists={playlists} />

--- a/src/components/music/MusicExperience.tsx
+++ b/src/components/music/MusicExperience.tsx
@@ -34,9 +34,7 @@ type SpotifyTimeRange = 'short_term' | 'medium_term' | 'long_term';
 
 interface QueryState<T> {
   data: T;
-  error: string | null;
   loading: boolean;
-  refetch: () => Promise<void>;
 }
 
 interface DisclosureSectionProps {
@@ -151,17 +149,6 @@ function ResourceState<T>({
 }) {
   if (query.loading) {
     return <div className="music-feedback">{loadingLabel}</div>;
-  }
-
-  if (query.error) {
-    return (
-      <div className="music-feedback music-feedback-error">
-        <p>{query.error}</p>
-        <button type="button" onClick={() => void query.refetch()}>
-          Retry
-        </button>
-      </div>
-    );
   }
 
   if (

--- a/src/components/music/NowPlayingWidget.tsx
+++ b/src/components/music/NowPlayingWidget.tsx
@@ -62,14 +62,18 @@ export default function NowPlayingWidget({
   mode = 'footer',
   introSeed = 0,
 }: NowPlayingWidgetProps) {
-  const { data: track } = useNowPlayingTrack();
+  const query = useNowPlayingTrack();
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
+  const track = query.kind === 'success' ? query.data : null;
+  const isUnavailable = query.kind === 'unavailable';
   const isListening = Boolean(track?.name);
   const spotifyHref = getSpotifyHref(track);
   const albumArt = pickSpotifyCoverImage(track?.album?.images);
-  const title = track?.name ?? 'Not Playing';
+  const title = isUnavailable
+    ? 'Now playing is unavailable right now.'
+    : (track?.name ?? 'Not Playing');
   const subtitle = getWidgetSubtitle(track, mode);
 
   useEffect(() => {
@@ -117,10 +121,12 @@ export default function NowPlayingWidget({
 
   const introLine = useMemo<WidgetContextLine>(
     () =>
-      isListening
-        ? itemFromSeed(PLAYING_INTROS, introSeed)
-        : itemFromSeed(NOT_PLAYING_INTROS, introSeed),
-    [isListening, introSeed],
+      isUnavailable
+        ? { emoji: '🎧', copy: 'music is temporarily unavailable' }
+        : isListening
+          ? itemFromSeed(PLAYING_INTROS, introSeed)
+          : itemFromSeed(NOT_PLAYING_INTROS, introSeed),
+    [isListening, introSeed, isUnavailable],
   );
 
   const infoHref = mode === 'page' ? spotifyHref : '/music';

--- a/src/components/music/NowPlayingWidget.tsx
+++ b/src/components/music/NowPlayingWidget.tsx
@@ -62,7 +62,7 @@ export default function NowPlayingWidget({
   mode = 'footer',
   introSeed = 0,
 }: NowPlayingWidgetProps) {
-  const { data: track, error, refetch } = useNowPlayingTrack();
+  const { data: track } = useNowPlayingTrack();
   const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
@@ -140,15 +140,6 @@ export default function NowPlayingWidget({
           {introLine.emoji}
         </span>
         <span className="music-now-playing-intro-copy">{introLine.copy}</span>
-        {error && (
-          <button
-            type="button"
-            className="music-inline-button"
-            onClick={() => void refetch()}
-          >
-            Retry
-          </button>
-        )}
       </div>
 
       <div className="music-now-playing-card">

--- a/src/components/music/music.css
+++ b/src/components/music/music.css
@@ -218,23 +218,6 @@
   color: var(--color-light-slate);
 }
 
-.music-feedback-error {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.music-feedback-error button {
-  padding: 0.85rem 1.1rem;
-  border: 1px solid var(--color-green);
-  border-radius: 4px;
-  background: transparent;
-  color: var(--color-green);
-  font-family: var(--font-mono);
-  font-size: 13px;
-}
-
 .music-list {
   display: flex;
   flex-direction: column;

--- a/src/hooks/useSpotify.ts
+++ b/src/hooks/useSpotify.ts
@@ -18,20 +18,16 @@ type SpotifyTimeRange = 'short_term' | 'medium_term' | 'long_term';
 
 interface ResourceState<T> {
   data: T;
-  error: string | null;
   loading: boolean;
-  refetch: () => Promise<void>;
 }
 
 function useSpotifyResource<T>(
   fetcher: () => Promise<T | undefined>,
   initialValue: T,
-  errorMessage: string,
 ): ResourceState<T> {
   const initialValueRef = useRef(initialValue);
   const [data, setData] = useState<T>(initialValue);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   const run = useCallback(async () => {
     setLoading(true);
@@ -40,15 +36,13 @@ function useSpotifyResource<T>(
 
     if (nextData === undefined) {
       setData(initialValueRef.current);
-      setError(errorMessage);
       setLoading(false);
       return;
     }
 
     setData(nextData);
-    setError(null);
     setLoading(false);
-  }, [errorMessage, fetcher]);
+  }, [fetcher]);
 
   useEffect(() => {
     void run();
@@ -56,9 +50,7 @@ function useSpotifyResource<T>(
 
   return {
     data,
-    error,
     loading,
-    refetch: run,
   };
 }
 
@@ -85,11 +77,7 @@ export function useNowPlayingTrack(): ResourceState<SpotifyTrack | null> {
     [],
   );
 
-  return useSpotifyResource(
-    fetcher,
-    null,
-    "Couldn't fetch Ayush's now playing track.",
-  );
+  return useSpotifyResource(fetcher, null);
 }
 
 export function useTopSpotifyItems(
@@ -102,13 +90,7 @@ export function useTopSpotifyItems(
     return response?.items ?? undefined;
   }, [limit, timeRange, type]);
 
-  return useSpotifyResource(
-    fetcher,
-    [],
-    type === 'artists'
-      ? "Couldn't fetch Ayush's top artists."
-      : "Couldn't fetch Ayush's top tracks.",
-  );
+  return useSpotifyResource(fetcher, []);
 }
 
 export function useFavouritePlaylist(
@@ -119,11 +101,7 @@ export function useFavouritePlaylist(
     [playlistId],
   );
 
-  return useSpotifyResource(
-    fetcher,
-    null,
-    "Couldn't fetch Ayush's favourite playlist.",
-  );
+  return useSpotifyResource(fetcher, null);
 }
 
 export function useRecentlyPlayedTracks(
@@ -135,11 +113,7 @@ export function useRecentlyPlayedTracks(
     return items.length ? getUniqueRecentlyPlayedTracks(items) : undefined;
   }, [limit]);
 
-  return useSpotifyResource(
-    fetcher,
-    [],
-    "Couldn't fetch recently played tracks.",
-  );
+  return useSpotifyResource(fetcher, []);
 }
 
 export function useSavedTracks(
@@ -150,11 +124,7 @@ export function useSavedTracks(
     return response?.items ?? undefined;
   }, [limit]);
 
-  return useSpotifyResource(
-    fetcher,
-    [],
-    "Couldn't fetch recently saved tracks.",
-  );
+  return useSpotifyResource(fetcher, []);
 }
 
 export function useUserPlaylists(limit = 20): ResourceState<SpotifyPlaylist[]> {
@@ -163,5 +133,5 @@ export function useUserPlaylists(limit = 20): ResourceState<SpotifyPlaylist[]> {
     return response?.items ?? undefined;
   }, [limit]);
 
-  return useSpotifyResource(fetcher, [], "Couldn't fetch Ayush's playlists.");
+  return useSpotifyResource(fetcher, []);
 }

--- a/src/hooks/useSpotify.ts
+++ b/src/hooks/useSpotify.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import {
   fetchCurrentTrack,
@@ -7,6 +7,7 @@ import {
   fetchCurrentUsersSavedTracks,
   fetchCurrentUsersTopItems,
   fetchPlaylistById,
+  type SpotifyResult,
   type SpotifyArtist,
   type SpotifyPlaylist,
   type SpotifyRecentlyPlayedItem,
@@ -15,43 +16,30 @@ import {
 } from '@utils/spotify';
 
 type SpotifyTimeRange = 'short_term' | 'medium_term' | 'long_term';
+type SpotifyTopItemType = 'artists' | 'tracks';
+type SpotifyTopItem<T extends SpotifyTopItemType> = T extends 'artists'
+  ? SpotifyArtist
+  : SpotifyTrack;
 
-interface ResourceState<T> {
-  data: T;
-  loading: boolean;
-}
+export type SpotifyResourceState<T> = { kind: 'loading' } | SpotifyResult<T>;
 
 function useSpotifyResource<T>(
-  fetcher: () => Promise<T | undefined>,
-  initialValue: T,
-): ResourceState<T> {
-  const initialValueRef = useRef(initialValue);
-  const [data, setData] = useState<T>(initialValue);
-  const [loading, setLoading] = useState(false);
+  fetcher: () => Promise<SpotifyResult<T>>,
+): SpotifyResourceState<T> {
+  const [state, setState] = useState<SpotifyResourceState<T>>({
+    kind: 'loading',
+  });
 
   const run = useCallback(async () => {
-    setLoading(true);
-
-    const nextData = await fetcher();
-
-    if (nextData === undefined) {
-      setData(initialValueRef.current);
-      setLoading(false);
-      return;
-    }
-
-    setData(nextData);
-    setLoading(false);
+    setState({ kind: 'loading' });
+    setState(await fetcher());
   }, [fetcher]);
 
   useEffect(() => {
     void run();
   }, [run]);
 
-  return {
-    data,
-    loading,
-  };
+  return state;
 }
 
 function getUniqueRecentlyPlayedTracks(
@@ -71,67 +59,96 @@ function getUniqueRecentlyPlayedTracks(
   });
 }
 
-export function useNowPlayingTrack(): ResourceState<SpotifyTrack | null> {
-  const fetcher = useCallback(
-    async () => (await fetchCurrentTrack()) ?? null,
-    [],
-  );
+export function useNowPlayingTrack(): SpotifyResourceState<SpotifyTrack> {
+  const fetcher = useCallback(() => fetchCurrentTrack(), []);
 
-  return useSpotifyResource(fetcher, null);
+  return useSpotifyResource(fetcher);
 }
 
-export function useTopSpotifyItems(
-  type: 'artists' | 'tracks',
+export function useTopSpotifyItems<T extends SpotifyTopItemType>(
+  type: T,
   timeRange: SpotifyTimeRange,
   limit = 20,
-): ResourceState<SpotifyArtist[] | SpotifyTrack[]> {
-  const fetcher = useCallback(async () => {
+): SpotifyResourceState<SpotifyTopItem<T>[]> {
+  const fetcher = useCallback(async (): Promise<
+    SpotifyResult<SpotifyTopItem<T>[]>
+  > => {
     const response = await fetchCurrentUsersTopItems(type, timeRange, limit);
-    return response?.items ?? undefined;
+
+    if (response.kind !== 'success') {
+      return response;
+    }
+
+    return { kind: 'success', data: response.data.items ?? [] };
   }, [limit, timeRange, type]);
 
-  return useSpotifyResource(fetcher, []);
+  return useSpotifyResource(fetcher);
 }
 
 export function useFavouritePlaylist(
   playlistId = '3qWhbV6ul3Bfl2iHrN4TYn',
-): ResourceState<SpotifyPlaylist | null> {
+): SpotifyResourceState<SpotifyPlaylist> {
   const fetcher = useCallback(
-    async () => (await fetchPlaylistById(playlistId)) ?? null,
+    () => fetchPlaylistById(playlistId),
     [playlistId],
   );
 
-  return useSpotifyResource(fetcher, null);
+  return useSpotifyResource(fetcher);
 }
 
 export function useRecentlyPlayedTracks(
   limit = 20,
-): ResourceState<SpotifyRecentlyPlayedItem[]> {
-  const fetcher = useCallback(async () => {
+): SpotifyResourceState<SpotifyRecentlyPlayedItem[]> {
+  const fetcher = useCallback(async (): Promise<
+    SpotifyResult<SpotifyRecentlyPlayedItem[]>
+  > => {
     const response = await fetchCurrentUsersRecentlyPlayed(limit);
-    const items = response?.items ?? [];
-    return items.length ? getUniqueRecentlyPlayedTracks(items) : undefined;
+
+    if (response.kind !== 'success') {
+      return response;
+    }
+
+    const items = getUniqueRecentlyPlayedTracks(response.data.items ?? []);
+    return items.length > 0
+      ? { kind: 'success', data: items }
+      : { kind: 'empty' };
   }, [limit]);
 
-  return useSpotifyResource(fetcher, []);
+  return useSpotifyResource(fetcher);
 }
 
 export function useSavedTracks(
   limit = 20,
-): ResourceState<SpotifySavedTrackItem[]> {
-  const fetcher = useCallback(async () => {
+): SpotifyResourceState<SpotifySavedTrackItem[]> {
+  const fetcher = useCallback(async (): Promise<
+    SpotifyResult<SpotifySavedTrackItem[]>
+  > => {
     const response = await fetchCurrentUsersSavedTracks(limit);
-    return response?.items ?? undefined;
+
+    if (response.kind !== 'success') {
+      return response;
+    }
+
+    return { kind: 'success', data: response.data.items ?? [] };
   }, [limit]);
 
-  return useSpotifyResource(fetcher, []);
+  return useSpotifyResource(fetcher);
 }
 
-export function useUserPlaylists(limit = 20): ResourceState<SpotifyPlaylist[]> {
-  const fetcher = useCallback(async () => {
+export function useUserPlaylists(
+  limit = 20,
+): SpotifyResourceState<SpotifyPlaylist[]> {
+  const fetcher = useCallback(async (): Promise<
+    SpotifyResult<SpotifyPlaylist[]>
+  > => {
     const response = await fetchCurrentUserPlaylists(limit);
-    return response?.items ?? undefined;
+
+    if (response.kind !== 'success') {
+      return response;
+    }
+
+    return { kind: 'success', data: response.data.items ?? [] };
   }, [limit]);
 
-  return useSpotifyResource(fetcher, []);
+  return useSpotifyResource(fetcher);
 }

--- a/src/utils/spotify.ts
+++ b/src/utils/spotify.ts
@@ -3,6 +3,23 @@ const SPOTIFY_FAILURE_BACKOFF_MS = 10_000;
 
 let spotifyBackoffUntil = 0;
 
+export type SpotifyResult<T> =
+  | { kind: 'success'; data: T }
+  | { kind: 'empty' }
+  | { kind: 'unavailable' };
+
+function spotifySuccess<T>(data: T): SpotifyResult<T> {
+  return { kind: 'success', data };
+}
+
+function spotifyEmpty<T>(): SpotifyResult<T> {
+  return { kind: 'empty' };
+}
+
+function spotifyUnavailable<T>(): SpotifyResult<T> {
+  return { kind: 'unavailable' };
+}
+
 function startSpotifyBackoff(): boolean {
   const now = Date.now();
   const shouldLog = now >= spotifyBackoffUntil;
@@ -52,6 +69,12 @@ interface SpotifyCurrentTrackResponse {
   currently_playing_type?: string;
   item?: SpotifyTrack;
 }
+
+type SpotifyTopItemType = 'artists' | 'tracks';
+
+type SpotifyTopItem<T extends SpotifyTopItemType> = T extends 'artists'
+  ? SpotifyArtist
+  : SpotifyTrack;
 
 export interface SpotifyImage {
   url: string;
@@ -107,12 +130,15 @@ const SPOTIFY_NOW_PLAYING_TTL_MS = 30_000;
 const SPOTIFY_LIBRARY_TTL_MS = 5 * 60_000;
 
 interface SpotifyCacheEntry {
-  data: unknown;
+  result: SpotifyResult<unknown>;
   expiresAt: number;
 }
 
 const spotifyResponseCache = new Map<string, SpotifyCacheEntry>();
-const spotifyInflightRequests = new Map<string, Promise<unknown>>();
+const spotifyInflightRequests = new Map<
+  string,
+  Promise<SpotifyResult<unknown>>
+>();
 
 function cacheTtlForPath(path: string): number {
   return path === '/me/player/currently-playing'
@@ -123,7 +149,7 @@ function cacheTtlForPath(path: string): number {
 async function spotifyGet<T>(
   path: string,
   params: Record<string, string | number> = {},
-): Promise<T | undefined> {
+): Promise<SpotifyResult<T>> {
   const qs = new URLSearchParams({
     path,
     ...Object.fromEntries(
@@ -134,19 +160,19 @@ async function spotifyGet<T>(
 
   const cached = spotifyResponseCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
-    return cached.data as T | undefined;
+    return cached.result as SpotifyResult<T>;
   }
 
   const inflight = spotifyInflightRequests.get(cacheKey);
   if (inflight) {
-    return (await inflight) as T | undefined;
+    return (await inflight) as SpotifyResult<T>;
   }
 
   if (spotifyBackoffUntil > Date.now()) {
-    return undefined;
+    return spotifyUnavailable();
   }
 
-  const request = (async (): Promise<T | undefined> => {
+  const request = (async (): Promise<SpotifyResult<T>> => {
     try {
       const response = await fetch(`${SPOTIFY_PROXY}?${qs.toString()}`, {
         headers: {
@@ -158,22 +184,22 @@ async function spotifyGet<T>(
         if (startSpotifyBackoff()) {
           await logSpotifyResponseFailure(response);
         }
-        return undefined;
+        return spotifyUnavailable();
       }
 
-      const data =
+      const result =
         response.status === 204 || response.status === 202
-          ? undefined
-          : ((await response.json()) as T);
+          ? spotifyEmpty<T>()
+          : spotifySuccess((await response.json()) as T);
 
       spotifyBackoffUntil = 0;
       // Cache 204s too ("nothing playing" is a valid, reusable answer).
       spotifyResponseCache.set(cacheKey, {
-        data,
+        result,
         expiresAt: Date.now() + cacheTtlForPath(path),
       });
 
-      return data;
+      return result;
     } catch (error) {
       if (startSpotifyBackoff()) {
         console.warn(
@@ -181,7 +207,7 @@ async function spotifyGet<T>(
           error,
         );
       }
-      return undefined;
+      return spotifyUnavailable();
     }
   })();
 
@@ -194,82 +220,107 @@ async function spotifyGet<T>(
   }
 }
 
-export async function fetchCurrentTrack(): Promise<SpotifyTrack | undefined> {
-  const data = await spotifyGet<SpotifyCurrentTrackResponse>(
+export async function fetchCurrentTrack(): Promise<
+  SpotifyResult<SpotifyTrack>
+> {
+  const result = await spotifyGet<SpotifyCurrentTrackResponse>(
     '/me/player/currently-playing',
   );
 
-  if (data?.currently_playing_type === 'track' && data.item) {
-    return data.item;
+  if (result.kind !== 'success') {
+    return result;
   }
 
-  return undefined;
+  const { data } = result;
+
+  if (data.currently_playing_type === 'track' && data.item) {
+    return spotifySuccess(data.item);
+  }
+
+  return spotifyEmpty();
 }
 
 export async function fetchPlaylistById(
   playlistId: string,
-): Promise<SpotifyPlaylist | undefined> {
+): Promise<SpotifyResult<SpotifyPlaylist>> {
   return spotifyGet<SpotifyPlaylist>(`/playlists/${playlistId}`);
 }
 
 export async function fetchCurrentUserPlaylists(
   limit = 20,
-): Promise<SpotifyPagingResponse<SpotifyPlaylist> | undefined> {
-  const data = await spotifyGet<SpotifyPagingResponse<SpotifyPlaylist>>(
+): Promise<SpotifyResult<SpotifyPagingResponse<SpotifyPlaylist>>> {
+  const result = await spotifyGet<SpotifyPagingResponse<SpotifyPlaylist>>(
     '/me/playlists',
     { limit },
   );
 
-  if (data?.items?.length) {
-    return data;
+  if (result.kind !== 'success') {
+    return result;
   }
 
-  return undefined;
+  if (result.data.items?.length) {
+    return result;
+  }
+
+  return spotifyEmpty();
 }
 
 export async function fetchCurrentUsersRecentlyPlayed(
   limit = 20,
-): Promise<SpotifyPagingResponse<SpotifyRecentlyPlayedItem> | undefined> {
-  const data = await spotifyGet<
+): Promise<SpotifyResult<SpotifyPagingResponse<SpotifyRecentlyPlayedItem>>> {
+  const result = await spotifyGet<
     SpotifyPagingResponse<SpotifyRecentlyPlayedItem>
   >('/me/player/recently-played', { limit });
 
-  if (data?.items?.length) {
-    return data;
+  if (result.kind !== 'success') {
+    return result;
   }
 
-  return undefined;
+  if (result.data.items?.length) {
+    return result;
+  }
+
+  return spotifyEmpty();
 }
 
 export async function fetchCurrentUsersSavedTracks(
   limit = 20,
-): Promise<SpotifyPagingResponse<SpotifySavedTrackItem> | undefined> {
-  const data = await spotifyGet<SpotifyPagingResponse<SpotifySavedTrackItem>>(
+): Promise<SpotifyResult<SpotifyPagingResponse<SpotifySavedTrackItem>>> {
+  const result = await spotifyGet<SpotifyPagingResponse<SpotifySavedTrackItem>>(
     '/me/tracks',
     { limit },
   );
 
-  if (data?.items?.length) {
-    return data;
+  if (result.kind !== 'success') {
+    return result;
   }
 
-  return undefined;
+  if (result.data.items?.length) {
+    return result;
+  }
+
+  return spotifyEmpty();
 }
 
-export async function fetchCurrentUsersTopItems(
-  type: 'artists' | 'tracks' = 'tracks',
+export async function fetchCurrentUsersTopItems<T extends SpotifyTopItemType>(
+  type: T,
   timeRange: 'short_term' | 'medium_term' | 'long_term' = 'short_term',
   limit = 20,
-): Promise<SpotifyPagingResponse<SpotifyArtist | SpotifyTrack> | undefined> {
-  const data = await spotifyGet<
-    SpotifyPagingResponse<SpotifyArtist | SpotifyTrack>
-  >(`/me/top/${type}`, { time_range: timeRange, limit });
+): Promise<SpotifyResult<SpotifyPagingResponse<SpotifyTopItem<T>>>> {
+  const result = await spotifyGet<SpotifyPagingResponse<SpotifyTopItem<T>>>(
+    `/me/top/${type}`,
+    { time_range: timeRange, limit },
+  );
 
-  if (data?.items?.length) {
-    return data;
+  if (result.kind !== 'success') {
+    return result;
   }
 
-  return undefined;
+  if (result.data.items?.length) {
+    return result;
+  }
+
+  return spotifyEmpty();
 }
 
 export function pickSpotifyCoverImage(

--- a/src/utils/spotify.ts
+++ b/src/utils/spotify.ts
@@ -3,6 +3,36 @@ const SPOTIFY_FAILURE_BACKOFF_MS = 10_000;
 
 let spotifyBackoffUntil = 0;
 
+function startSpotifyBackoff(): boolean {
+  const now = Date.now();
+  const shouldLog = now >= spotifyBackoffUntil;
+
+  spotifyBackoffUntil = now + SPOTIFY_FAILURE_BACKOFF_MS;
+  return shouldLog;
+}
+
+function hasSpotifyErrorCode(value: unknown, code: string): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'error' in value &&
+    value.error === code
+  );
+}
+
+async function logSpotifyResponseFailure(response: Response) {
+  const body: unknown = await response.json().catch(() => null);
+
+  if (hasSpotifyErrorCode(body, 'reauthorization_required')) {
+    console.warn(
+      '[spotify] Authorization needs renewal. Update SPOTIFY_REFRESH_TOKEN and redeploy.',
+    );
+    return;
+  }
+
+  console.warn(`[spotify] Request failed with HTTP ${response.status}.`);
+}
+
 interface SpotifyExternalUrls {
   spotify?: string;
 }
@@ -125,7 +155,9 @@ async function spotifyGet<T>(
       });
 
       if (!response.ok) {
-        spotifyBackoffUntil = Date.now() + SPOTIFY_FAILURE_BACKOFF_MS;
+        if (startSpotifyBackoff()) {
+          await logSpotifyResponseFailure(response);
+        }
         return undefined;
       }
 
@@ -143,8 +175,12 @@ async function spotifyGet<T>(
 
       return data;
     } catch (error) {
-      spotifyBackoffUntil = Date.now() + SPOTIFY_FAILURE_BACKOFF_MS;
-      console.error('[spotify]', error);
+      if (startSpotifyBackoff()) {
+        console.warn(
+          '[spotify] Request failed before Spotify responded.',
+          error,
+        );
+      }
       return undefined;
     }
   })();

--- a/test/spotify-client.test.mjs
+++ b/test/spotify-client.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+const originalFetch = globalThis.fetch;
+const originalConsoleWarn = console.warn;
+let moduleVersion = 0;
+
+async function loadSpotifyClient() {
+  moduleVersion += 1;
+  return import(`../src/utils/spotify.ts?test=${moduleVersion}`);
+}
+
+function mockSpotifyResponse(body, status = 200) {
+  globalThis.fetch = async () =>
+    new Response(body == null ? null : JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.warn = originalConsoleWarn;
+});
+
+test('keeps Spotify empty, successful, and unavailable results distinct', async (t) => {
+  await t.test(
+    'treats a no-content now-playing response as empty',
+    async () => {
+      const spotify = await loadSpotifyClient();
+      mockSpotifyResponse(null, 204);
+
+      assert.deepEqual(await spotify.fetchCurrentTrack(), { kind: 'empty' });
+    },
+  );
+
+  await t.test('treats a valid empty collection as empty', async () => {
+    const spotify = await loadSpotifyClient();
+    mockSpotifyResponse({ items: [] });
+
+    assert.deepEqual(await spotify.fetchCurrentUsersTopItems('tracks'), {
+      kind: 'empty',
+    });
+  });
+
+  await t.test('keeps populated collections successful', async () => {
+    const spotify = await loadSpotifyClient();
+    mockSpotifyResponse({ items: [{ name: 'A track' }] });
+
+    assert.deepEqual(await spotify.fetchCurrentUsersTopItems('tracks'), {
+      kind: 'success',
+      data: { items: [{ name: 'A track' }] },
+    });
+  });
+
+  await t.test(
+    'treats generic and reauthorization failures as unavailable',
+    async () => {
+      for (const [status, body] of [
+        [502, { error: 'Failed to proxy Spotify request' }],
+        [503, { error: 'reauthorization_required' }],
+      ]) {
+        const spotify = await loadSpotifyClient();
+        mockSpotifyResponse(body, status);
+        console.warn = () => {};
+
+        assert.deepEqual(await spotify.fetchCurrentTrack(), {
+          kind: 'unavailable',
+        });
+      }
+    },
+  );
+});

--- a/test/spotify-proxy.test.cjs
+++ b/test/spotify-proxy.test.cjs
@@ -1,0 +1,71 @@
+const { afterEach, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const functionPath = require.resolve('../netlify/functions/spotify.cjs');
+const originalFetch = globalThis.fetch;
+const originalConsoleError = console.error;
+const originalEnvironment = {
+  clientId: process.env.SPOTIFY_CLIENT_ID,
+  clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+  refreshToken: process.env.SPOTIFY_REFRESH_TOKEN,
+};
+
+function loadHandler(tokenError) {
+  process.env.SPOTIFY_CLIENT_ID = 'client-id';
+  process.env.SPOTIFY_CLIENT_SECRET = 'client-secret';
+  process.env.SPOTIFY_REFRESH_TOKEN = 'refresh-token';
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify(tokenError), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  console.error = () => {};
+  delete require.cache[functionPath];
+
+  return require(functionPath).handler;
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.error = originalConsoleError;
+  for (const [key, value] of Object.entries({
+    SPOTIFY_CLIENT_ID: originalEnvironment.clientId,
+    SPOTIFY_CLIENT_SECRET: originalEnvironment.clientSecret,
+    SPOTIFY_REFRESH_TOKEN: originalEnvironment.refreshToken,
+  })) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  delete require.cache[functionPath];
+});
+
+test('reports a safe reauthorization error when Spotify revokes the refresh token', async () => {
+  const handler = loadHandler({ error: 'invalid_grant' });
+
+  const response = await handler({
+    httpMethod: 'GET',
+    queryStringParameters: { path: '/me/top/tracks' },
+  });
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: 'reauthorization_required',
+  });
+});
+
+test('keeps other token failures generic', async () => {
+  const handler = loadHandler({ error: 'invalid_client' });
+
+  const response = await handler({
+    httpMethod: 'GET',
+    queryStringParameters: { path: '/me/top/tracks' },
+  });
+
+  assert.equal(response.statusCode, 502);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: 'Failed to proxy Spotify request',
+  });
+});


### PR DESCRIPTION
## Summary
- classify revoked Spotify refresh tokens as a safe reauthorization-required response
- emit one console-only diagnostic per backoff window and keep visitor fallbacks quiet
- add focused proxy classification tests

## Root cause
Spotify refresh-token expiry was surfaced as an undifferentiated 502, leaving no actionable client-side signal.

## Validation
- npm test
- npm run check
- npm run lint
- npm run build
- Prettier check
- React Doctor changed-scope scan (pre-existing Fast Refresh warnings only)