### PR TITLE
perf: run GTM off main thread via Partytown, add analytics preconnects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,10 @@ React hooks live in `src/hooks/useSpotify.ts`; now-playing render appears in the
 
 Blog comments and the music song-recommendation form are stored in a Supabase `comments` table (columns: `post_id`, `author`, `content`, `hidden`, `created_at`; new rows default to `hidden = true` pending approval). The browser never talks to Supabase directly — the Astro API route `src/pages/api/comments.ts` (`prerender = false`, deployed as a serverless function) proxies GET/POST using server-side env vars `SUPABASE_URL` and `SUPABASE_KEY` (publishable key; RLS restricts reads to `hidden = false`). Client hook: `src/hooks/useComments.ts`. `post_id` values are load-bearing: blog posts use the raw frontmatter slug (e.g. `/blog/grid-vs-flex`), the music page uses `/music/`.
 
+### Analytics
+
+Google Tag Manager (`googleAnalyticsID` in `src/config/index.ts`) runs off the main thread via `@astrojs/partytown` (configured in `astro.config.mjs`, `forward: ['dataLayer.push']`). Both `gtag.js` and its inline bootstrap in `src/components/BaseHead.astro` are `type="text/partytown"` (keep `is:inline` on them — without it Astro's script pipeline tries to process a type it doesn't recognize). If GTM stops firing, check the worker/service-worker (DevTools > Application), not just the main thread; any new GTM trigger that reads off `window` beyond `dataLayer.push` needs adding to `forward`. See `docs/adr/0001-partytown-for-gtm.md`.
+
 ### Animations
 
 CSS-only reveal system: `.page-reveal`/`.is-revealed` classes in `global.css`, triggered by `src/components/PageReveal.astro` (re-runs on `astro:page-load` for view transitions; skips elements inside `astro-island` — islands manage their own reveal state). Respect `prefers-reduced-motion` (handled centrally in `global.css`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ React hooks live in `src/hooks/useSpotify.ts`; now-playing render appears in the
 
 Blog comments and the music song-recommendation form are stored in a Supabase `comments` table (columns: `post_id`, `author`, `content`, `hidden`, `created_at`; new rows default to `hidden = true` pending approval). The browser never talks to Supabase directly — the Astro API route `src/pages/api/comments.ts` (`prerender = false`, deployed as a serverless function) proxies GET/POST using server-side env vars `SUPABASE_URL` and `SUPABASE_KEY` (publishable key; RLS restricts reads to `hidden = false`). Client hook: `src/hooks/useComments.ts`. `post_id` values are load-bearing: blog posts use the raw frontmatter slug (e.g. `/blog/grid-vs-flex`), the music page uses `/music/`.
 
+### Analytics
+
+Google Tag Manager (`googleAnalyticsID` in `src/config/index.ts`) runs off the main thread via `@astrojs/partytown` (configured in `astro.config.mjs`, `forward: ['dataLayer.push']`). Both `gtag.js` and its inline bootstrap in `src/components/BaseHead.astro` are `type="text/partytown"` (keep `is:inline` on them — without it Astro's script pipeline tries to process a type it doesn't recognize). If GTM stops firing, check the worker/service-worker (DevTools > Application), not just the main thread; any new GTM trigger that reads off `window` beyond `dataLayer.push` needs adding to `forward`. See `docs/adr/0001-partytown-for-gtm.md`.
+
 ### Animations
 
 CSS-only reveal system: `.page-reveal`/`.is-revealed` classes in `global.css`, triggered by `src/components/PageReveal.astro` (re-runs on `astro:page-load` for view transitions; skips elements inside `astro-island` — islands manage their own reveal state). Respect `prefers-reduced-motion` (handled centrally in `global.css`).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import netlify from '@astrojs/netlify';
+import partytown from '@astrojs/partytown';
 import tailwindcss from '@tailwindcss/vite';
 import rehypeExternalLinks from 'rehype-external-links';
 import { loadEnv } from 'vite';
@@ -25,6 +26,9 @@ export default defineConfig({
     react(),
     mdx(),
     sitemap(),
+    // Runs Google Tag Manager's gtag.js in a web worker instead of main
+    // thread. dataLayer.push must stay forwarded for gtag() calls to reach it.
+    partytown({ config: { forward: ['dataLayer.push'] } }),
   ],
 
   vite: {

--- a/docs/adr/0001-partytown-for-gtm.md
+++ b/docs/adr/0001-partytown-for-gtm.md
@@ -1,0 +1,51 @@
+# 1. Run Google Tag Manager via Partytown
+
+## Status
+
+Accepted
+
+## Context
+
+Lighthouse flagged two related performance opportunities, both caused by `gtag.js`
+(Google Tag Manager), which was loaded as a plain `<script async src>` plus an inline
+bootstrap script in `src/components/BaseHead.astro`:
+
+- **Reduce unused JavaScript** — `gtag.js` transfers 156.3 KiB, of which 67.4 KiB goes
+  unused, and Lighthouse ties this to LCP.
+- **Preconnect to required origins** — no early connection to `analytics.google.com` /
+  `stats.g.doubleclick.net`, which `gtag.js` calls out to.
+
+Two fix approaches for the first issue were considered:
+
+1. **Defer `gtag.js` until `window.load`/idle.** No new dependency, smallest diff, keeps
+   the existing inline-script pattern. But it only delays when the cost is paid — the
+   same bytes still parse and execute on the main thread, just later.
+2. **Run GTM inside a Web Worker via `@astrojs/partytown`.** Removes GTM's JS execution
+   from the main thread entirely (not just delays it), which is the standard, documented
+   fix for exactly this class of Lighthouse finding. Costs one new dependency and changes
+   how the script tags are declared (`type="text/partytown"` instead of a native
+   `<script>` type).
+
+## Decision
+
+Adopt `@astrojs/partytown`. Both `gtag.js` and its inline bootstrap in
+`src/components/BaseHead.astro` are marked `type="text/partytown"` (kept `is:inline` so
+Astro doesn't try to bundle/process them). `astro.config.mjs` registers the integration
+with `config.forward: ['dataLayer.push']`, so `gtag()` calls made in the worker are
+proxied back onto the real `window.dataLayer` on the main thread.
+
+Preconnect hints were added for the three origins GTM talks to
+(`www.googletagmanager.com`, `analytics.google.com`, `stats.g.doubleclick.net`) alongside
+this change, since they're only useful once the origins they warm are actually used.
+
+## Consequences
+
+- GTM/GA now depends on Partytown's worker + service-worker bootstrap
+  (`~partytown/*.js`, emitted to `dist/` at build time by the integration). If GTM stops
+  firing, check the worker (DevTools > Application > Service Workers, or the Partytown
+  debug flag) before assuming the main-thread code is at fault.
+- Any *future* GTM/GA trigger that reads from `window` (beyond `dataLayer.push`) needs to
+  be added to `config.forward` in `astro.config.mjs`, or it will silently fail inside the
+  worker's isolated `window` proxy.
+- `is:inline` must stay on both script tags — without it, Astro's own script processing
+  pipeline (bundling/dedup) would run on a script it doesn't recognize as JS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@astrojs/check": "0.9.8",
         "@astrojs/mdx": "5.0.3",
         "@astrojs/netlify": "7.0.13",
+        "@astrojs/partytown": "2.1.7",
         "@astrojs/react": "5.0.3",
         "@astrojs/sitemap": "3.7.2",
         "@tailwindcss/vite": "4.2.2",
@@ -260,6 +261,16 @@
         "shiki": "^4.0.2",
         "smol-toml": "^1.6.0",
         "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@astrojs/partytown": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.7.tgz",
+      "integrity": "sha512-dbffmNmJ+sAJ0/aXSaLX4aI04EZS/2C6Mm/+fmd4ikqWO7hV6nIi0sug8Z3c+yqedJNi1swFvpwluWmGjLHNzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@qwik.dev/partytown": "^0.13.2",
+        "mrmime": "^2.0.1"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -5313,6 +5324,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@qwik.dev/partytown": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.13.2.tgz",
+      "integrity": "sha512-Umls4bSkuzqLVcGvf8OgwIn/OldproSAbaQ/iYGe8VPYBpl2CaOSxabWwkeC72LDFqxVL0b0q8XlI8MuChDyzg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.7"
+      },
+      "bin": {
+        "partytown": "bin/partytown.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@astrojs/check": "0.9.8",
     "@astrojs/mdx": "5.0.3",
     "@astrojs/netlify": "7.0.13",
+    "@astrojs/partytown": "2.1.7",
     "@astrojs/react": "5.0.3",
     "@astrojs/sitemap": "3.7.2",
     "@tailwindcss/vite": "4.2.2",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -173,12 +173,21 @@ const googleAnalyticsScript = `
 {
   googleAnalyticsID && (
     <>
+      {/* Preconnect to the origins gtag.js talks to, so the (now worker-owned)
+         connections are already warm by the time it makes requests. */}
+      <link rel="preconnect" href="https://www.googletagmanager.com" />
+      <link rel="preconnect" href="https://analytics.google.com" />
+      <link rel="preconnect" href="https://stats.g.doubleclick.net" />
       <script
         is:inline
-        async
+        type="text/partytown"
         src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsID}`}
       />
-      <script is:inline set:html={googleAnalyticsScript} />
+      <script
+        is:inline
+        type="text/partytown"
+        set:html={googleAnalyticsScript}
+      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
Fixes two Lighthouse performance opportunities flagged on the Performance category (score 82), both caused by Google Tag Manager's `gtag.js`:

- **Reduce unused JavaScript** (flagged LCP, ~0.75s savings) — `gtag.js` transfers 156.3 KiB, 67.4 KiB unused, loaded synchronously in `<head>`.
- **Preconnect to required origins** (flagged FCP+LCP, ~0.28s savings) — no early connection to `stats.g.doubleclick.net` / `analytics.google.com`.

## Changes
- Adopt `@astrojs/partytown` to run `gtag.js` and its inline bootstrap in a web worker instead of the main thread (`astro.config.mjs`, `config.forward: ['dataLayer.push']`).
- Both GTM `<script>` tags in `src/components/BaseHead.astro` marked `type="text/partytown"` (kept `is:inline` so Astro doesn't try to process them).
- Added `<link rel="preconnect">` for `www.googletagmanager.com`, `analytics.google.com`, `stats.g.doubleclick.net`.
- Recorded the decision (and rejected alternative — deferring `gtag.js` load until `window.load`/idle) as the repo's first ADR: `docs/adr/0001-partytown-for-gtm.md`.
- Short "Analytics" note added to `CLAUDE.md`/`AGENTS.md` so future debugging knows to check the worker.

## Verification
- `npm run build` — clean, `dist/~partytown/*` assets emitted correctly.
- `npm run lint` — clean.
- Verified end-to-end in dev via chrome-devtools MCP: `gtag.js` loads through the worker, `dataLayer.push` forwarding works, and both `analytics.google.com` and `stats.g.doubleclick.net` beacons fire successfully (204s) with no Partytown-related console errors.
- Confirmed against live prod (pre-fix) that neither preconnect hints nor off-main-thread execution existed prior to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)