### PR TITLE
Harden the public Spotify presentation API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 SPOTIFY_CLIENT_ID="your_client_id"
 SPOTIFY_CLIENT_SECRET="your_client_secret"
 SPOTIFY_REFRESH_TOKEN="your_refresh_token"
+# Production-only Cloudflare-to-Netlify authentication (minimum 32 characters)
+SPOTIFY_ORIGIN_KEY_CURRENT="generate_an_independent_256_bit_random_value"
+# Set only during the documented dual-key rotation procedure
+# SPOTIFY_ORIGIN_KEY_NEXT="generate_the_next_independent_256_bit_random_value"
 
 # Supabase (server-side only, used by /api/comments)
 SUPABASE_URL=https://your-project.supabase.co

--- a/.github/workflows/spotify-health.yml
+++ b/.github/workflows/spotify-health.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  HEALTH_URL: https://ayushgupta.tech/.netlify/functions/spotify?path=%2Fme%2Ftop%2Ftracks&limit=1
+  HEALTH_URL: https://ayushgupta.tech/api/spotify?resource=top-tracks&range=short_term
   ISSUE_TITLE: '[Spotify Health] Production check failing'
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ There are no automated tests; verification is done by building plus checking pag
 ### Content → Pages pipeline
 
 Content collections are defined in `src/content.config.ts` and live in `src/content/` (blog MDX, jobs, featured/projects, uses, hero, about, etc.). Pages in `src/pages/`:
+
 - Blog post pages from `src/content/blog/` via `src/pages/blog/[slug].astro` (routed by frontmatter `slug`, helpers in `src/utils/blog.ts`)
 - Tag pages at `/blog/tags/{tag}` via `src/pages/blog/tags/[tag].astro`
 
@@ -40,11 +41,13 @@ Tailwind v4 + plain CSS. Design tokens (colors, fonts) are CSS custom properties
 
 ### Spotify integration
 
-Spotify API calls are proxied through a Netlify Function (`netlify/functions/spotify.cjs`) with a strict path allowlist. Server-side env vars: `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`. Serverless invocation count is a deliberate constraint, kept low by four cache layers — don't add refetching without considering them:
-1. The function caches its OAuth token across warm invocations and sends `Netlify-CDN-Cache-Control: ... durable ...` so the CDN serves repeats without invoking it (30s for now-playing, 5min for library endpoints).
-2. `spotifyGet` in `src/utils/spotify.ts` has a module-level TTL cache + in-flight dedupe that survives island remounts and soft navigations.
+Spotify API calls are exposed as a fixed, least-privilege presentation API at `/api/spotify` by `netlify/functions/spotify.cjs`. The function accepts resource keys rather than arbitrary Spotify paths, returns purpose-built public DTOs, and requires a Cloudflare-injected origin key in production. Server-side env vars: `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`, `SPOTIFY_ORIGIN_KEY_CURRENT`, and optional `SPOTIFY_ORIGIN_KEY_NEXT`. Never configure `SPOTIFY_LOCAL_DEV_BYPASS` in Netlify; the local scripts set it only for the Netlify emulator.
+
+Serverless invocation count is a deliberate constraint, kept low by three layers — don't add refetching without considering them:
+
+1. The function caches its OAuth token across warm invocations and uses Netlify's CDN only when Spotify's upstream cache policy permits it, capped at 30s for now-playing and 5min for collections.
+2. `spotifyGet` in `src/utils/spotify.ts` has a response-header-aware module cache plus in-flight dedupe that survives island remounts and soft navigations.
 3. The music page's `<details>` sections mount their query panels only on first open (see `DisclosureSection` in `MusicExperience.tsx`).
-4. Track preview audio uses `preload='none'`.
 
 React hooks live in `src/hooks/useSpotify.ts`; now-playing render appears in the footer widget, the homepage hero line, and the music page.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ There are no automated tests; verification is done by building plus checking pag
 ### Content → Pages pipeline
 
 Content collections are defined in `src/content.config.ts` and live in `src/content/` (blog MDX, jobs, featured/projects, uses, hero, about, etc.). Pages in `src/pages/`:
+
 - Blog post pages from `src/content/blog/` via `src/pages/blog/[slug].astro` (routed by frontmatter `slug`, helpers in `src/utils/blog.ts`)
 - Tag pages at `/blog/tags/{tag}` via `src/pages/blog/tags/[tag].astro`
 
@@ -40,11 +41,13 @@ Tailwind v4 + plain CSS. Design tokens (colors, fonts) are CSS custom properties
 
 ### Spotify integration
 
-Spotify API calls are proxied through a Netlify Function (`netlify/functions/spotify.cjs`) with a strict path allowlist. Server-side env vars: `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`. Serverless invocation count is a deliberate constraint, kept low by four cache layers — don't add refetching without considering them:
-1. The function caches its OAuth token across warm invocations and sends `Netlify-CDN-Cache-Control: ... durable ...` so the CDN serves repeats without invoking it (30s for now-playing, 5min for library endpoints).
-2. `spotifyGet` in `src/utils/spotify.ts` has a module-level TTL cache + in-flight dedupe that survives island remounts and soft navigations.
+Spotify API calls are exposed as a fixed, least-privilege presentation API at `/api/spotify` by `netlify/functions/spotify.cjs`. The function accepts resource keys rather than arbitrary Spotify paths, returns purpose-built public DTOs, and requires a Cloudflare-injected origin key in production. Server-side env vars: `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`, `SPOTIFY_REFRESH_TOKEN`, `SPOTIFY_ORIGIN_KEY_CURRENT`, and optional `SPOTIFY_ORIGIN_KEY_NEXT`. Never configure `SPOTIFY_LOCAL_DEV_BYPASS` in Netlify; the local scripts set it only for the Netlify emulator.
+
+Serverless invocation count is a deliberate constraint, kept low by three layers — don't add refetching without considering them:
+
+1. The function caches its OAuth token across warm invocations and uses Netlify's CDN only when Spotify's upstream cache policy permits it, capped at 30s for now-playing and 5min for collections.
+2. `spotifyGet` in `src/utils/spotify.ts` has a response-header-aware module cache plus in-flight dedupe that survives island remounts and soft navigations.
 3. The music page's `<details>` sections mount their query panels only on first open (see `DisclosureSection` in `MusicExperience.tsx`).
-4. Track preview audio uses `preload='none'`.
 
 React hooks live in `src/hooks/useSpotify.ts`; now-playing render appears in the footer widget, the homepage hero line, and the music page.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Spotify and Supabase features use server-side environment variables for the Netl
 
 ## Deployment
 
-The site is deployed on [Netlify](https://netlify.com). Static assets live in `public/`, the Spotify proxy runs from `netlify/functions/spotify.cjs`, and the Supabase comments proxy runs from the Astro API route `src/pages/api/comments.ts`.
+The site is deployed on [Netlify](https://netlify.com). Static assets live in `public/`, the fixed Spotify presentation API at `/api/spotify` runs from `netlify/functions/spotify.cjs`, and the Supabase comments proxy runs from the Astro API route `src/pages/api/comments.ts`. Production Spotify requests are restricted to traffic authenticated by the Cloudflare edge; see `docs/spotify-security-runbook.md` before changing or deploying that integration.
 
 ## Links
 

--- a/docs/astro-migration-plan.md
+++ b/docs/astro-migration-plan.md
@@ -300,7 +300,7 @@ Skip porting: `.gatsby-image-outer-wrapper`, PrismStyles (replaced by Shiki).
 ### Current Main Branch Baseline (April 20, 2026)
 
 - Spotify secrets are already server-side on `main` via `netlify/functions/spotify.cjs`; the old direct client-secret flow is no longer the source of truth.
-- The current client utility calls `/.netlify/functions/spotify?path=...` and the server-side proxy enforces an allowlist of Spotify paths instead of exposing arbitrary upstream access.
+- The Spotify client calls the fixed `/api/spotify?resource=...` presentation endpoint; the server owns every upstream path, parameter, limit, and response DTO.
 - The current music route surface on `main` is:
   - live now playing widget
   - top tracks with short / medium / long term toggle

--- a/docs/spotify-security-runbook.md
+++ b/docs/spotify-security-runbook.md
@@ -1,0 +1,300 @@
+# Spotify security operations runbook
+
+This runbook protects the public Spotify presentation endpoint without placing
+Spotify, Netlify, or origin-key secrets in the browser or repository. Complete
+the Cloudflare cutover before merging the enforcement pull request.
+
+## Security model
+
+The public page may be copied by visitors; the goal is to expose only the fixed
+data already rendered, prevent direct access to the general Spotify API, slow
+scraping, and stop requests from bypassing Cloudflare.
+
+- Cloudflare accepts public traffic, restricts methods and bursts, bypasses its
+  cache, and overwrites `X-Spotify-Origin-Key` before forwarding the request.
+- Netlify validates that origin key, applies a per-domain-and-IP backstop, maps
+  fixed resource names to fixed Spotify requests, and returns minimal DTOs.
+- Netlify's CDN cache varies on both query parameters and the origin-key header.
+  A cached authorized response must not satisfy an unauthenticated direct-origin
+  request.
+- Spotify remains protected by its OAuth scopes and platform quota. Spotify
+  does not document an origin allowlist, referrer restriction, IP allowlist, or
+  developer-configurable quota for this use case.
+
+References:
+
+- [Spotify app settings](https://developer.spotify.com/documentation/web-api/concepts/apps)
+- [Spotify rate limits](https://developer.spotify.com/documentation/web-api/concepts/rate-limits)
+- [Netlify function rate limiting](https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/)
+- [Netlify cache-key variation](https://docs.netlify.com/build/caching/caching-overview/)
+- [Cloudflare rate-limiting rules](https://developers.cloudflare.com/waf/rate-limiting-rules/)
+- [Cloudflare request-header transforms](https://developers.cloudflare.com/rules/transform/request-header-modification/)
+
+## Secret inventory
+
+Keep these values separate:
+
+| Secret                | Stored in                                                                       | Rotation trigger                                                                             |
+| --------------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Spotify client secret | Netlify Functions environment                                                   | Suspected compromise                                                                         |
+| Spotify refresh token | Netlify Functions environment and password manager                              | Reauthorize before six-month expiry, revocation, or compromise                               |
+| Spotify origin key    | Netlify production environment, Cloudflare transform rule, and password manager | Rotation test with refresh-token renewal, or immediately after Cloudflare/Netlify compromise |
+
+Never use the Spotify client secret or refresh token as an origin key. Never put
+an origin key in GitHub Actions, a deploy-preview environment, source code,
+browser code, command history, issue text, function logs, or response bodies.
+`npm run dev` sets `SPOTIFY_LOCAL_DEV_BYPASS=true` for the local process because
+Netlify's Astro emulator does not provide a deploy context, while setting
+`NETLIFY_DEV` disables that emulator's function routing. Never configure
+`SPOTIFY_LOCAL_DEV_BYPASS` in the Netlify dashboard or any deployed environment.
+
+Generate each origin key with a password manager capable of producing at least
+256 random bits. If that is unavailable, run `openssl rand -base64 32` in a
+private terminal and immediately store the output in the password manager.
+
+## Pre-cutover inventory
+
+1. In Netlify, confirm `ayushgupta.tech` and `www.ayushgupta.tech` are healthy
+   production domains and the Netlify certificate is valid.
+2. Export the complete existing Netlify DNS/NS1 zone. Save the export and a
+   screenshot of the nameservers in the password manager or another private
+   operations vault, not this repository.
+3. Record every apex and subdomain record, including MX, TXT, CAA, verification,
+   redirects, and any records Cloudflare's automatic import misses.
+4. Record the registrar's current nameservers as the rollback target:
+   `dns1.p01.nsone.net` through `dns4.p01.nsone.net`.
+5. Record current TTLs and lower them in advance if the provider permits it.
+6. Check the parent-zone DS record with `dig +short ayushgupta.tech DS`.
+
+Read-only DNS checks on 8 August 2026 found the four NS1 nameservers above, two
+apex and `www` IPv4 answers, existing GoDaddy mail MX records, SPF and site
+verification TXT records, and no DS or CAA record. This is only a point-in-time
+cross-check; the exported zone is authoritative and must be reviewed again at
+cutover.
+
+### DNSSEC sequence
+
+If a DS record exists at cutover, remove/disable it at the registrar before
+changing nameservers and wait until public resolvers no longer return it. A
+stale DS record paired with new unsigned nameservers can make the entire domain
+unresolvable. After Cloudflare is authoritative and stable, enable Cloudflare
+DNSSEC and publish the exact DS values Cloudflare provides at the registrar.
+Verify with a validating resolver. If no DS record exists, proceed with the
+nameserver change and enable Cloudflare DNSSEC only after the zone is stable.
+
+## Prepare Cloudflare Free
+
+1. Add `ayushgupta.tech` to Cloudflare Free.
+2. Compare the imported zone line by line with the private NS1 export. Restore
+   all mail and verification records before delegation.
+3. For the apex, use Cloudflare's flattened CNAME support and point `@` to
+   `apex-loadbalancer.netlify.com`. For `www`, use the exact Netlify
+   `*.netlify.app` hostname shown under Netlify **Domain management**. Do not
+   preserve transient resolved Netlify IPs as permanent records.
+4. Keep the Netlify-facing web records **DNS only** while validating the imported
+   zone and Netlify certificate.
+5. Change the nameservers at the registrar to the pair assigned by Cloudflare.
+6. Wait until Cloudflare reports the zone active and public NS lookups return
+   the Cloudflare nameservers.
+7. Confirm mail, verification records, the apex redirect behavior, Netlify
+   custom-domain health, and the existing Netlify certificate before enabling
+   the proxy.
+8. Wait for Cloudflare Universal SSL to become active for the apex and `www`.
+9. Set Cloudflare SSL/TLS encryption mode to **Full (strict)**. Never use
+   **Flexible**. If Netlify needs to renew its certificate and reports a
+   validation problem, temporarily switch the web records to DNS only, renew,
+   verify, and restore the proxy.
+10. Turn the apex and `www` records to **Proxied** and verify the whole site
+    before adding enforcement rules.
+
+Netlify's supported external-DNS destination is documented in
+[Configure external DNS](https://docs.netlify.com/manage/domains/configure-domains/configure-external-dns/).
+
+## Configure the Spotify endpoint rules
+
+Use this exact path condition for every rule:
+
+```text
+http.request.uri.path eq "/api/spotify"
+```
+
+### Request-header transform
+
+Create a **Modify Request Header** transform scoped to the path above:
+
+- operation: **Set static** (overwrite, not add-if-missing);
+- header: `X-Spotify-Origin-Key`;
+- value: the independent 256-bit origin key from the password manager.
+
+Overwriting the header prevents a visitor-supplied value from reaching Netlify.
+Never paste the key into a rule description or screenshot.
+
+### Method firewall
+
+Create a WAF custom rule with this expression and block action:
+
+```text
+(http.request.uri.path eq "/api/spotify" and http.request.method ne "GET")
+```
+
+The function also returns `405` with `Allow: GET`; the edge rule rejects obvious
+non-GET traffic before a function invocation.
+
+### Burst rate limit
+
+Create Cloudflare Free's path-based rate rule:
+
+- expression: the exact Spotify path condition;
+- characteristic/counting key: source IP;
+- threshold: 12 requests in 10 seconds;
+- action: block for the selected mitigation period;
+- status: `429`;
+- content type: `application/json`;
+- response body: `{"error":"rate_limited"}`.
+
+Use a short mitigation period supported by the dashboard and record the chosen
+value in the private operations notes. The application performs no automatic
+retry, so a normal page load remains below this burst threshold.
+
+### Cache and notifications
+
+Create a cache rule for the exact Spotify path with **Cache eligibility: Bypass**.
+Netlify remains the only shared cache so its Spotify-aware freshness and
+origin-key variation stay authoritative.
+
+Enable Cloudflare dashboard and email security notifications for WAF and rate
+events. Do not add Cloudflare credentials to GitHub Actions or Terraform for
+this setup.
+
+## Configure Netlify before merging
+
+1. In Netlify environment variables, add
+   `SPOTIFY_ORIGIN_KEY_CURRENT` with **Functions** scope and **Production**
+   deploy context only.
+2. Do not set either origin key for Deploy Previews or branch deploys. Their
+   Spotify function must fail closed.
+3. Confirm `SPOTIFY_LOCAL_DEV_BYPASS` is absent from every Netlify deploy
+   context. It belongs only to the local `npm run dev` process.
+4. Leave `SPOTIFY_ORIGIN_KEY_NEXT` unset until a rotation.
+5. Trigger a production deploy of the current code. It still ignores the new
+   header, which makes this a safe time to finish the Cloudflare cutover.
+6. Confirm Cloudflare adds the header by checking that the existing Spotify UI
+   remains healthy. Never log the header value to prove this; validate only via
+   behavior after enforcement is deployed.
+
+## Merge gate and rollout
+
+Do not merge the enforcement pull request until all pre-merge boxes pass:
+
+- [ ] Cloudflare is authoritative for the zone and Universal SSL is active.
+- [ ] Full (strict) succeeds for the apex and `www`.
+- [ ] Netlify still reports the custom domains and certificate as healthy.
+- [ ] The header transform, GET-only WAF rule, burst limit, and cache bypass are
+      enabled on the exact function path.
+- [ ] `SPOTIFY_ORIGIN_KEY_CURRENT` is stored in Netlify production only and is
+      identical to the Cloudflare transform value.
+- [ ] `SPOTIFY_LOCAL_DEV_BYPASS` is not configured in Netlify.
+- [ ] The existing production music page and health workflow are healthy
+      through Cloudflare.
+- [ ] The Netlify deploy log recognizes the code-defined Spotify function rate
+      rule: 30 requests per 60 seconds, aggregated by IP and domain. Netlify
+      warns that invalid rules may not fail a deploy, so absence from the
+      post-processing log is a failed gate.
+
+Then merge the code PR. Enforcement takes effect with the production deploy.
+
+## Post-merge verification
+
+Use bodies only to read the safe `error` category. Do not print request headers,
+environment variables, or Netlify function configuration.
+
+1. Request
+   `https://ayushgupta.tech/api/spotify?resource=top-tracks&range=short_term`.
+   It must return `200` with an array of at most ten public track DTOs.
+2. Open `/music`, expand every section, and verify populated, genuine-empty,
+   and unavailable states remain distinct. Open a rendered item and confirm it
+   goes to the matching Spotify content.
+3. Request the same path on the site's direct production `*.netlify.app`
+   hostname without the origin header. It must return `403` even after the
+   custom-domain response has been cached.
+4. Request the Deploy Preview function. It must fail closed because the preview
+   has no origin key. The preview music UI should show calm unavailable copy.
+5. Try unknown and incompatible inputs (`path`, `limit`, `offset`, duplicate
+   `resource`, invalid `range`, and `range` on `now-playing`). Each must return
+   `400` without affecting Spotify.
+6. Send a non-GET request. Cloudflare should block it; a direct authorized
+   function test should return `405` with `Allow: GET`.
+7. In a controlled window, send 13 requests inside ten seconds from one IP. The
+   13th must receive Cloudflare's JSON `429`. Stop, wait for the configured
+   mitigation period, and confirm valid traffic recovers.
+8. Separately and carefully confirm more than 30 sustained requests in one
+   minute activates Netlify's backstop. Do this once, not as a recurring load
+   test, and stop immediately after observing `429`.
+9. Manually dispatch the Spotify Health workflow. It must return `200` through
+   the custom domain without any GitHub-held origin secret.
+10. Search repository changes, browser network details, response bodies,
+    GitHub Actions, and function logs for accidental secret disclosure. Search
+    for variable names, not secret values.
+
+## Dual-key origin rotation
+
+1. Generate a new independent 256-bit key and store it in the password manager.
+2. Set it as `SPOTIFY_ORIGIN_KEY_NEXT` in Netlify production and deploy.
+3. Confirm the custom domain still works with Cloudflare's current key. This
+   proves both slots are accepted without switching traffic.
+4. Overwrite Cloudflare's transform value with the next key.
+5. Verify custom-domain success, direct-production-origin rejection, and health
+   workflow success.
+6. Copy the next key into `SPOTIFY_ORIGIN_KEY_CURRENT` in Netlify production,
+   remove `SPOTIFY_ORIGIN_KEY_NEXT`, and deploy.
+7. Verify the public music page, API, direct-origin rejection, and health
+   workflow again.
+8. Delete the old key from the password manager after the verification window.
+
+If Cloudflare or Netlify access is compromised, rotate immediately. Otherwise,
+test this sequence alongside the six-month Spotify refresh-token renewal.
+
+## Spotify authorization maintenance
+
+- Remain in Development Mode while this is a one-owner portfolio integration.
+  Extended Mode is not an ingress-security control.
+- Continue Authorization Code flow. PKCE does not authenticate visitors to this
+  server-side proxy.
+- Keep only: `user-read-currently-playing`, `user-read-recently-played`,
+  `user-top-read`, `user-library-read`, and `playlist-read-private`.
+- TODO before the next reauthorization: determine whether a displayed playlist
+  requires `playlist-read-collaborative`. If none does, omit that scope from the
+  next grant. Scope removal requires reauthorization; code changes alone do not
+  reduce an existing grant.
+- Record every authorization date privately and renew before six months.
+- If Spotify returns a replacement refresh token, use the replacement. A warm
+  function instance adopts it in memory, but a rotated value must be persisted
+  to the Netlify environment through a controlled operator workflow; never log
+  it to recover it.
+- Rotate the Spotify client secret only after suspected compromise. It is not
+  part of routine refresh-token or origin-key renewal.
+
+## Rollback
+
+### Enforcement failure
+
+Revert the production code deploy to the last version that ignored the origin
+header. Leave Cloudflare, DNS, TLS, method blocking, burst limiting, cache bypass,
+and header injection in place while diagnosing. The old function safely ignores
+the extra header.
+
+### Cloudflare/DNS failure
+
+1. If only a Cloudflare rule is faulty, disable that rule first and keep DNS in
+   place.
+2. If proxy TLS is faulty, switch the Netlify-facing records to DNS only and
+   recheck the Netlify certificate.
+3. For a full DNS rollback, restore the private NS1 zone export and registrar
+   nameservers recorded before cutover. If Cloudflare DNSSEC was enabled, remove
+   its DS record at the registrar before restoring NS1 unless the restored
+   provider is already configured for that exact DS record.
+4. Wait for authoritative nameserver propagation, then confirm web, mail,
+   Netlify custom-domain health, certificate health, and Spotify health.
+
+Do not delete the Cloudflare zone or the private NS1 export until the rollback
+window has closed and all post-merge checks have remained healthy.

--- a/netlify/functions/spotify.cjs
+++ b/netlify/functions/spotify.cjs
@@ -1,20 +1,397 @@
+const crypto = require('node:crypto');
+
 const fetch = globalThis.fetch || require('node-fetch');
 
 const TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token';
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1';
+const FAVOURITE_PLAYLIST_ID = '3qWhbV6ul3Bfl2iHrN4TYn';
+const ORIGIN_KEY_HEADER = 'x-spotify-origin-key';
+const ORIGIN_KEY_MINIMUM_LENGTH = 32;
+const CACHE_VARY = 'query,header=X-Spotify-Origin-Key';
+const TIME_RANGES = new Set(['short_term', 'medium_term', 'long_term']);
 
-// Reuse the access token across invocations of a warm function instance
-// instead of hitting Spotify's token endpoint on every request.
+const RESOURCES = {
+  'now-playing': {
+    path: '/me/player/currently-playing',
+    maximumCacheSeconds: 30,
+    requiresRange: false,
+  },
+  'top-tracks': {
+    path: '/me/top/tracks',
+    maximumCacheSeconds: 300,
+    requiresRange: true,
+  },
+  'top-artists': {
+    path: '/me/top/artists',
+    maximumCacheSeconds: 300,
+    requiresRange: true,
+  },
+  'favourite-playlist': {
+    path: `/playlists/${FAVOURITE_PLAYLIST_ID}`,
+    maximumCacheSeconds: 300,
+    requiresRange: false,
+  },
+  'recently-played': {
+    path: '/me/player/recently-played',
+    maximumCacheSeconds: 300,
+    requiresRange: false,
+  },
+  'saved-tracks': {
+    path: '/me/tracks',
+    maximumCacheSeconds: 300,
+    requiresRange: false,
+  },
+  'saved-playlists': {
+    path: '/me/playlists',
+    maximumCacheSeconds: 300,
+    requiresRange: false,
+  },
+};
+
 let cachedToken = { value: null, expiresAt: 0 };
+let replacementRefreshToken = null;
 
 class SpotifyAuthorizationError extends Error {}
+class SpotifyRateLimitError extends Error {
+  constructor(retryAfter) {
+    super('Spotify rate limit reached');
+    this.retryAfter = retryAfter;
+  }
+}
+class SpotifyUpstreamError extends Error {}
 
-async function isInvalidGrant(response) {
-  const data = await response.json().catch(() => null);
+function baseHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'X-Content-Type-Options': 'nosniff',
+    'Cache-Control': 'no-store',
+    'Netlify-Vary': CACHE_VARY,
+  };
+}
 
-  return (
-    typeof data === 'object' && data !== null && data.error === 'invalid_grant'
+function jsonResponse(statusCode, error, extraHeaders = {}) {
+  return {
+    statusCode,
+    headers: { ...baseHeaders(), ...extraHeaders },
+    body: JSON.stringify({ error }),
+  };
+}
+
+function isRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value, field) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new SpotifyUpstreamError(`Malformed Spotify ${field}`);
+  }
+
+  return value;
+}
+
+function optionalNonNegativeInteger(value, field) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (!Number.isInteger(value) || value < 0) {
+    throw new SpotifyUpstreamError(`Malformed Spotify ${field}`);
+  }
+
+  return value;
+}
+
+function spotifyUrl(value, field) {
+  const rawUrl = requiredString(value, field);
+
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== 'https:' || url.hostname !== 'open.spotify.com') {
+      throw new Error('Unexpected Spotify URL');
+    }
+  } catch {
+    throw new SpotifyUpstreamError(`Malformed Spotify ${field}`);
+  }
+
+  return rawUrl;
+}
+
+function artworkImage(images, field) {
+  if (!Array.isArray(images) || images.length === 0) {
+    return null;
+  }
+
+  const source = images[1] ?? images[0];
+  if (!isRecord(source)) {
+    throw new SpotifyUpstreamError(`Malformed Spotify ${field}`);
+  }
+
+  const rawUrl = requiredString(source.url, `${field} URL`);
+  try {
+    const url = new URL(rawUrl);
+    if (url.protocol !== 'https:') {
+      throw new Error('Artwork URL must use HTTPS');
+    }
+  } catch {
+    throw new SpotifyUpstreamError(`Malformed Spotify ${field} URL`);
+  }
+
+  const image = { url: rawUrl };
+  const width = optionalNonNegativeInteger(source.width, `${field} width`);
+  const height = optionalNonNegativeInteger(source.height, `${field} height`);
+
+  if (width !== null) image.width = width;
+  if (height !== null) image.height = height;
+
+  return image;
+}
+
+function mapTrack(value) {
+  if (!isRecord(value) || !isRecord(value.album)) {
+    throw new SpotifyUpstreamError('Malformed Spotify track');
+  }
+  if (!Array.isArray(value.artists) || value.artists.length === 0) {
+    throw new SpotifyUpstreamError('Malformed Spotify track artists');
+  }
+  if (!isRecord(value.external_urls)) {
+    throw new SpotifyUpstreamError('Malformed Spotify track URL');
+  }
+
+  const artists = value.artists.map((artist) => {
+    if (!isRecord(artist)) {
+      throw new SpotifyUpstreamError('Malformed Spotify track artist');
+    }
+    return requiredString(artist.name, 'track artist name');
+  });
+
+  return {
+    id: requiredString(value.id, 'track ID'),
+    name: requiredString(value.name, 'track name'),
+    albumName: requiredString(value.album.name, 'album name'),
+    image: artworkImage(value.album.images, 'album artwork'),
+    artists,
+    spotifyUrl: spotifyUrl(value.external_urls.spotify, 'track URL'),
+  };
+}
+
+function mapArtist(value) {
+  if (!isRecord(value) || !isRecord(value.external_urls)) {
+    throw new SpotifyUpstreamError('Malformed Spotify artist');
+  }
+  if (
+    !Array.isArray(value.genres) ||
+    !value.genres.every((genre) => typeof genre === 'string')
+  ) {
+    throw new SpotifyUpstreamError('Malformed Spotify artist genres');
+  }
+
+  return {
+    id: requiredString(value.id, 'artist ID'),
+    name: requiredString(value.name, 'artist name'),
+    image: artworkImage(value.images, 'artist artwork'),
+    genres: value.genres,
+    spotifyUrl: spotifyUrl(value.external_urls.spotify, 'artist URL'),
+  };
+}
+
+function mapPlaylist(value) {
+  if (!isRecord(value) || !isRecord(value.external_urls)) {
+    throw new SpotifyUpstreamError('Malformed Spotify playlist');
+  }
+
+  const ownerName =
+    isRecord(value.owner) && typeof value.owner.display_name === 'string'
+      ? value.owner.display_name
+      : null;
+  const rawTrackCount =
+    isRecord(value.items) && value.items.total !== undefined
+      ? value.items.total
+      : isRecord(value.tracks)
+        ? value.tracks.total
+        : undefined;
+
+  return {
+    id: requiredString(value.id, 'playlist ID'),
+    name: requiredString(value.name, 'playlist name'),
+    image: artworkImage(value.images, 'playlist artwork'),
+    ownerName,
+    trackCount: optionalNonNegativeInteger(
+      rawTrackCount,
+      'playlist track count',
+    ),
+    spotifyUrl: spotifyUrl(value.external_urls.spotify, 'playlist URL'),
+  };
+}
+
+function mapCollection(value, itemMapper, itemSelector = (item) => item) {
+  if (!isRecord(value) || !Array.isArray(value.items)) {
+    throw new SpotifyUpstreamError('Malformed Spotify collection');
+  }
+
+  return value.items.slice(0, 10).map((item) => itemMapper(itemSelector(item)));
+}
+
+function mapSpotifyPayload(resource, payload) {
+  switch (resource) {
+    case 'now-playing':
+      if (!isRecord(payload)) {
+        throw new SpotifyUpstreamError('Malformed Spotify playback state');
+      }
+      if (payload.item === null || payload.item === undefined) {
+        return null;
+      }
+      if (payload.currently_playing_type !== 'track') {
+        return null;
+      }
+      return mapTrack(payload.item);
+    case 'top-tracks':
+      return mapCollection(payload, mapTrack);
+    case 'top-artists':
+      return mapCollection(payload, mapArtist);
+    case 'favourite-playlist':
+      return mapPlaylist(payload);
+    case 'recently-played':
+    case 'saved-tracks':
+      return mapCollection(payload, mapTrack, (item) => {
+        if (!isRecord(item)) {
+          throw new SpotifyUpstreamError('Malformed Spotify track item');
+        }
+        return item.track;
+      });
+    case 'saved-playlists':
+      return mapCollection(payload, mapPlaylist);
+    default:
+      throw new SpotifyUpstreamError('Unknown Spotify resource');
+  }
+}
+
+function getQueryEntries(event) {
+  if (typeof event.rawUrl === 'string') {
+    return [...new URL(event.rawUrl, 'https://local.invalid').searchParams];
+  }
+  if (typeof event.rawQuery === 'string') {
+    return [...new URLSearchParams(event.rawQuery)];
+  }
+  if (isRecord(event.multiValueQueryStringParameters)) {
+    return Object.entries(event.multiValueQueryStringParameters).flatMap(
+      ([key, values]) =>
+        Array.isArray(values) ? values.map((value) => [key, value]) : [],
+    );
+  }
+
+  return Object.entries(event.queryStringParameters ?? {});
+}
+
+function parseResourceRequest(event) {
+  let entries;
+  try {
+    entries = getQueryEntries(event);
+  } catch {
+    return null;
+  }
+
+  if (
+    entries.some(
+      ([key, value]) =>
+        (key !== 'resource' && key !== 'range') || typeof value !== 'string',
+    )
+  ) {
+    return null;
+  }
+
+  const resources = entries
+    .filter(([key]) => key === 'resource')
+    .map(([, value]) => value);
+  const ranges = entries
+    .filter(([key]) => key === 'range')
+    .map(([, value]) => value);
+
+  if (resources.length !== 1 || ranges.length > 1) {
+    return null;
+  }
+
+  const resource = resources[0];
+  const definition = RESOURCES[resource];
+  if (!definition) {
+    return null;
+  }
+
+  if (definition.requiresRange) {
+    if (ranges.length !== 1 || !TIME_RANGES.has(ranges[0])) {
+      return null;
+    }
+  } else if (ranges.length !== 0) {
+    return null;
+  }
+
+  const query = new URLSearchParams();
+  if (definition.requiresRange) {
+    query.set('time_range', ranges[0]);
+    query.set('limit', '10');
+  } else if (
+    resource === 'recently-played' ||
+    resource === 'saved-tracks' ||
+    resource === 'saved-playlists'
+  ) {
+    query.set('limit', '10');
+  }
+
+  return {
+    resource,
+    definition,
+    url: `${SPOTIFY_API_BASE}${definition.path}${query.size ? `?${query}` : ''}`,
+  };
+}
+
+function getRequestHeader(event, name) {
+  const headers = event.headers ?? {};
+  const match = Object.entries(headers).find(
+    ([headerName]) => headerName.toLowerCase() === name,
   );
+  return typeof match?.[1] === 'string' ? match[1] : null;
+}
+
+function constantTimeEqual(value, expected) {
+  const valueDigest = crypto.createHash('sha256').update(value).digest();
+  const expectedDigest = crypto.createHash('sha256').update(expected).digest();
+  return crypto.timingSafeEqual(valueDigest, expectedDigest);
+}
+
+function authorizeOrigin(event, localDevelopment) {
+  if (localDevelopment) {
+    return 'authorized';
+  }
+
+  const validKeys = [
+    process.env.SPOTIFY_ORIGIN_KEY_CURRENT,
+    process.env.SPOTIFY_ORIGIN_KEY_NEXT,
+  ].filter(
+    (key) => typeof key === 'string' && key.length >= ORIGIN_KEY_MINIMUM_LENGTH,
+  );
+
+  if (validKeys.length === 0) {
+    return 'misconfigured';
+  }
+
+  const suppliedKey = getRequestHeader(event, ORIGIN_KEY_HEADER);
+  if (!suppliedKey) {
+    return 'forbidden';
+  }
+
+  let authorized = false;
+  for (const key of validKeys) {
+    authorized = constantTimeEqual(suppliedKey, key) || authorized;
+  }
+
+  return authorized ? 'authorized' : 'forbidden';
+}
+
+async function readJson(response) {
+  try {
+    return await response.json();
+  } catch {
+    throw new SpotifyUpstreamError('Spotify returned malformed JSON');
+  }
 }
 
 async function getAccessToken() {
@@ -24,174 +401,242 @@ async function getAccessToken() {
 
   const clientId = process.env.SPOTIFY_CLIENT_ID;
   const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
-  const refreshToken = process.env.SPOTIFY_REFRESH_TOKEN;
+  const configuredRefreshToken = process.env.SPOTIFY_REFRESH_TOKEN;
 
-  if (!clientId || !clientSecret || !refreshToken) {
-    throw new Error('Missing Spotify credentials in environment variables');
+  if (!clientId || !clientSecret || !configuredRefreshToken) {
+    throw new SpotifyUpstreamError('Missing Spotify credentials');
   }
 
-  const basic = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
-
-  const body = new URLSearchParams();
-  body.append('grant_type', 'refresh_token');
-  body.append('refresh_token', refreshToken);
-
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: replacementRefreshToken ?? configuredRefreshToken,
+  });
   const response = await fetch(TOKEN_ENDPOINT, {
     method: 'POST',
     headers: {
-      Authorization: `Basic ${basic}`,
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body,
   });
-
-  if (!response.ok && (await isInvalidGrant(response))) {
-    throw new SpotifyAuthorizationError(
-      'Spotify authorization requires reauthentication',
+  if (response.status === 429) {
+    throw new SpotifyRateLimitError(
+      sanitizedRetryAfter(response.headers.get('retry-after')),
     );
   }
-
+  const data = await readJson(response);
+  if (!response.ok && isRecord(data) && data.error === 'invalid_grant') {
+    throw new SpotifyAuthorizationError('Spotify authorization needs renewal');
+  }
   if (!response.ok) {
-    throw new Error(`Token refresh failed: ${response.status}`);
+    throw new SpotifyUpstreamError('Spotify token refresh failed');
+  }
+  if (!isRecord(data)) {
+    throw new SpotifyUpstreamError('Malformed Spotify token response');
   }
 
-  const data = await response.json();
-  const lifetimeSeconds = Math.max((data.expires_in ?? 3600) - 60, 0);
+  const accessToken = requiredString(data.access_token, 'access token');
+  const expiresIn =
+    typeof data.expires_in === 'number' && data.expires_in > 0
+      ? data.expires_in
+      : 3600;
+
+  if (typeof data.refresh_token === 'string' && data.refresh_token.length > 0) {
+    replacementRefreshToken = data.refresh_token;
+  }
+
   cachedToken = {
-    value: data.access_token,
-    expiresAt: Date.now() + lifetimeSeconds * 1000,
+    value: accessToken,
+    expiresAt: Date.now() + Math.max(expiresIn - 60, 0) * 1000,
   };
 
-  return cachedToken.value;
+  return accessToken;
 }
 
-const ALLOWED_PATHS = [
-  '/me/player/currently-playing',
-  '/me/player/recently-played',
-  '/me/playlists',
-  '/me/tracks',
-  '/me/top/tracks',
-  '/me/top/artists',
-];
-
-function isAllowedPath(path) {
-  if (ALLOWED_PATHS.includes(path)) {
-    return true;
+function sanitizedRetryAfter(value) {
+  if (typeof value !== 'string' || !/^[1-9]\d*$/.test(value)) {
+    return null;
   }
-  // Allow /playlists/{id}
-  return /^\/playlists\/[A-Za-z0-9]+$/.test(path);
+
+  const seconds = Number(value);
+  return Number.isSafeInteger(seconds) ? String(seconds) : null;
 }
 
-// Let Netlify's CDN serve repeat requests without invoking the function.
-// "Now playing" stays fresh (30s); the library endpoints change slowly.
-function cacheHeadersForPath(path) {
-  const isNowPlaying = path === '/me/player/currently-playing';
+function effectiveCacheSeconds(cacheControl, applicationMaximum) {
+  if (typeof cacheControl !== 'string') {
+    return 0;
+  }
 
-  if (isNowPlaying) {
-    return {
-      'Cache-Control': 'public, max-age=30',
-      'Netlify-CDN-Cache-Control':
-        'public, durable, max-age=30, stale-while-revalidate=60',
-    };
+  const directives = cacheControl
+    .toLowerCase()
+    .split(',')
+    .map((directive) => directive.trim());
+
+  if (
+    directives.includes('no-store') ||
+    directives.includes('no-cache') ||
+    directives.includes('private')
+  ) {
+    return 0;
+  }
+
+  const freshnessValues = directives
+    .filter((directive) => /^(?:s-maxage|max-age)=\d+$/.test(directive))
+    .map((directive) => Number(directive.slice(directive.indexOf('=') + 1)))
+    .filter((value) => Number.isSafeInteger(value) && value > 0);
+
+  if (freshnessValues.length === 0) {
+    return 0;
+  }
+
+  return Math.min(...freshnessValues, applicationMaximum);
+}
+
+function successHeaders(spotifyResponse, applicationMaximum) {
+  const freshness = effectiveCacheSeconds(
+    spotifyResponse.headers.get('cache-control'),
+    applicationMaximum,
+  );
+
+  if (freshness === 0) {
+    return baseHeaders();
   }
 
   return {
-    'Cache-Control': 'public, max-age=300',
-    'Netlify-CDN-Cache-Control':
-      'public, durable, max-age=300, stale-while-revalidate=900',
+    ...baseHeaders(),
+    'Cache-Control': `public, max-age=${freshness}`,
+    'Netlify-CDN-Cache-Control': `public, durable, max-age=${freshness}`,
   };
 }
 
-exports.handler = async (event) => {
-  const headers = {
-    'Content-Type': 'application/json',
-    'Cache-Control': 'no-store',
-  };
+exports.config = {
+  path: '/api/spotify',
+  rateLimit: {
+    action: 'rate_limit',
+    aggregateBy: ['ip', 'domain'],
+    windowLimit: 30,
+    windowSize: 60,
+  },
+};
 
-  if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 204, headers };
+function isLocalDevelopment(context) {
+  const deployContext = context?.deploy?.context;
+  if (typeof deployContext === 'string') {
+    return deployContext === 'dev';
   }
 
+  // Astro's local Netlify emulator currently omits deploy context. The dev
+  // script sets this process-only marker; an explicit deployed context always
+  // takes precedence so the marker cannot bypass production enforcement.
+  return process.env.SPOTIFY_LOCAL_DEV_BYPASS === 'true';
+}
+
+async function handleEvent(event, { localDevelopment = false } = {}) {
   if (event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      headers,
-      body: JSON.stringify({ error: 'Method not allowed' }),
-    };
+    return jsonResponse(405, 'method_not_allowed', { Allow: 'GET' });
   }
 
-  const params = event.queryStringParameters || {};
-  const path = params.path;
-
-  if (!path) {
-    return {
-      statusCode: 400,
-      headers,
-      body: JSON.stringify({ error: 'Missing ?path= parameter' }),
-    };
+  const originAuthorization = authorizeOrigin(event, localDevelopment);
+  if (originAuthorization === 'misconfigured') {
+    return jsonResponse(503, 'configuration_error');
+  }
+  if (originAuthorization !== 'authorized') {
+    return jsonResponse(403, 'forbidden');
   }
 
-  if (!isAllowedPath(path)) {
-    return {
-      statusCode: 403,
-      headers,
-      body: JSON.stringify({ error: 'Path not allowed' }),
-    };
+  const request = parseResourceRequest(event);
+  if (!request) {
+    return jsonResponse(400, 'invalid_request');
   }
-
-  // Build upstream query string from all params except "path"
-  const upstream = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (key !== 'path') {
-      upstream.set(key, value);
-    }
-  }
-  const qs = upstream.toString();
-  const url = `${SPOTIFY_API_BASE}${path}${qs ? `?${qs}` : ''}`;
 
   try {
-    const access_token = await getAccessToken();
-
-    const spotifyRes = await fetch(url, {
+    const accessToken = await getAccessToken();
+    const spotifyResponse = await fetch(request.url, {
       headers: {
-        Authorization: `Bearer ${access_token}`,
-        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/json',
       },
     });
 
-    // No body key: dev emulation converts these to `new Response(body, ...)`,
-    // and undici rejects any non-null body (even '') for 204 responses.
-    if (spotifyRes.status === 204 || spotifyRes.status === 202) {
+    if (spotifyResponse.status === 429) {
+      throw new SpotifyRateLimitError(
+        sanitizedRetryAfter(spotifyResponse.headers.get('retry-after')),
+      );
+    }
+    if (spotifyResponse.status === 204 && request.resource === 'now-playing') {
       return {
-        statusCode: spotifyRes.status,
-        headers: { ...headers, ...cacheHeadersForPath(path) },
+        statusCode: 204,
+        headers: successHeaders(
+          spotifyResponse,
+          request.definition.maximumCacheSeconds,
+        ),
       };
     }
+    if (!spotifyResponse.ok) {
+      throw new SpotifyUpstreamError('Spotify API request failed');
+    }
 
-    const body = await spotifyRes.text();
+    const payload = mapSpotifyPayload(
+      request.resource,
+      await readJson(spotifyResponse),
+    );
+    const headers = successHeaders(
+      spotifyResponse,
+      request.definition.maximumCacheSeconds,
+    );
+
+    if (request.resource === 'now-playing' && payload === null) {
+      return { statusCode: 204, headers };
+    }
 
     return {
-      statusCode: spotifyRes.status,
-      headers: spotifyRes.ok
-        ? { ...headers, ...cacheHeadersForPath(path) }
-        : headers,
-      body,
+      statusCode: 200,
+      headers,
+      body: JSON.stringify(payload),
     };
-  } catch (err) {
+  } catch (error) {
     console.error(
       '[spotify proxy]',
-      err instanceof Error ? err.message : String(err),
+      error instanceof Error ? error.message : 'Unknown Spotify failure',
     );
-    const requiresReauthorization = err instanceof SpotifyAuthorizationError;
 
-    return {
-      statusCode: requiresReauthorization ? 503 : 502,
-      headers,
-      body: JSON.stringify({
-        error: requiresReauthorization
-          ? 'reauthorization_required'
-          : 'Failed to proxy Spotify request',
-      }),
-    };
+    if (error instanceof SpotifyAuthorizationError) {
+      return jsonResponse(503, 'reauthorization_required');
+    }
+    if (error instanceof SpotifyRateLimitError) {
+      return jsonResponse(
+        429,
+        'rate_limited',
+        error.retryAfter ? { 'Retry-After': error.retryAfter } : {},
+      );
+    }
+
+    return jsonResponse(502, 'upstream_failure');
   }
+}
+
+exports.default = async (request, context) => {
+  const url = new URL(request.url);
+  const result = await handleEvent(
+    {
+      httpMethod: request.method,
+      rawUrl: request.url,
+      rawQuery: url.search.slice(1),
+      headers: Object.fromEntries(request.headers),
+      queryStringParameters: Object.fromEntries(url.searchParams),
+    },
+    { localDevelopment: isLocalDevelopment(context) },
+  );
+
+  return new Response(result.body ?? null, {
+    status: result.statusCode,
+    headers: result.headers,
+  });
 };
+
+// Kept outside Netlify's reserved `handler` export so tests can exercise the
+// event-level boundary without downgrading this function from the v2 runtime.
+exports.testHandler = (event) =>
+  handleEvent(event, {
+    localDevelopment: process.env.SPOTIFY_LOCAL_DEV_BYPASS === 'true',
+  });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "SPOTIFY_LOCAL_DEV_BYPASS=true astro dev",
     "build": "astro build",
     "preview": "npm run dev --",
     "test": "node --experimental-strip-types --test test/spotify-proxy.test.cjs test/spotify-client.test.mjs",

--- a/src/components/HeroNowPlaying.tsx
+++ b/src/components/HeroNowPlaying.tsx
@@ -4,7 +4,7 @@ import {
   PLAYING_INTROS,
   getSpotifyHref,
   itemFromSeed,
-} from '@components/music/NowPlayingWidget';
+} from '@components/music/nowPlaying';
 import { useNowPlayingTrack } from '@hooks/useSpotify';
 
 interface HeroNowPlayingProps {

--- a/src/components/music/MusicExperience.tsx
+++ b/src/components/music/MusicExperience.tsx
@@ -13,14 +13,14 @@ import {
   useFavouritePlaylist,
   useRecentlyPlayedTracks,
   useSavedTracks,
-  useTopSpotifyItems,
+  useTopSpotifyArtists,
+  useTopSpotifyTracks,
   useUserPlaylists,
   type SpotifyResourceState,
 } from '@hooks/useSpotify';
 import {
-  getPlaylistTrackTotal,
-  pickSpotifyCoverImage,
   type SpotifyArtist,
+  type SpotifyImage,
   type SpotifyPlaylist,
   type SpotifyTrack,
 } from '@utils/spotify';
@@ -166,7 +166,7 @@ function MusicRow({
 }: {
   children: ReactNode;
   coverAlt: string;
-  coverImage: ReturnType<typeof pickSpotifyCoverImage>;
+  coverImage: SpotifyImage | null;
 }) {
   return (
     <article className="music-row">
@@ -201,19 +201,15 @@ function TrackList({
   return (
     <div className="music-list">
       {tracks.map((track, index) => {
-        const artists = (track.artists ?? [])
-          .map((artist) => artist.name)
-          .join(', ');
+        const artists = track.artists.join(', ');
 
         return (
           <MusicRow
-            key={track.id ?? `${prefix}-${index}`}
-            coverAlt={`${track.album?.name ?? track.name} album cover`}
-            coverImage={pickSpotifyCoverImage(track.album?.images)}
+            key={track.id || `${prefix}-${index}`}
+            coverAlt={`${track.albumName} album cover`}
+            coverImage={track.image}
           >
-            <ExternalLink href={track.external_urls?.spotify}>
-              {track.name}
-            </ExternalLink>
+            <ExternalLink href={track.spotifyUrl}>{track.name}</ExternalLink>
             <p>{artists}</p>
           </MusicRow>
         );
@@ -227,14 +223,12 @@ function ArtistList({ artists }: { artists: SpotifyArtist[] }) {
     <div className="music-list">
       {artists.map((artist, index) => (
         <MusicRow
-          key={artist.id ?? `artist-${index}`}
+          key={artist.id || `artist-${index}`}
           coverAlt={`${artist.name} artist image`}
-          coverImage={pickSpotifyCoverImage(artist.images)}
+          coverImage={artist.image}
         >
-          <ExternalLink href={artist.external_urls?.spotify}>
-            {artist.name}
-          </ExternalLink>
-          <p>{(artist.genres ?? []).join(', ')}</p>
+          <ExternalLink href={artist.spotifyUrl}>{artist.name}</ExternalLink>
+          <p>{artist.genres.join(', ')}</p>
         </MusicRow>
       ))}
     </div>
@@ -251,23 +245,23 @@ function PlaylistList({
   return (
     <div className="music-list">
       {playlists.map((playlist, index) => {
-        const total = getPlaylistTrackTotal(playlist);
-
         return (
           <MusicRow
-            key={playlist.id ?? `${prefix}-${index}`}
+            key={playlist.id || `${prefix}-${index}`}
             coverAlt={`${playlist.name} playlist cover`}
-            coverImage={pickSpotifyCoverImage(playlist.images)}
+            coverImage={playlist.image}
           >
             <div className="music-card-heading">
-              <ExternalLink href={playlist.external_urls?.spotify}>
+              <ExternalLink href={playlist.spotifyUrl}>
                 {playlist.name}
               </ExternalLink>
-              {playlist.owner?.display_name && (
-                <span> by {playlist.owner.display_name}</span>
-              )}
+              {playlist.ownerName && <span> by {playlist.ownerName}</span>}
             </div>
-            <p>{total == null ? '' : `${total} tracks`}</p>
+            <p>
+              {playlist.trackCount == null
+                ? ''
+                : `${playlist.trackCount} tracks`}
+            </p>
           </MusicRow>
         );
       })}
@@ -276,7 +270,7 @@ function PlaylistList({
 }
 
 function TopTracksPanel({ range }: { range: SpotifyTimeRange }) {
-  const query = useTopSpotifyItems('tracks', range, 10);
+  const query = useTopSpotifyTracks(range);
 
   return (
     <ResourceState
@@ -311,7 +305,7 @@ function FavouritePlaylistPanel() {
 }
 
 function RecentlyPlayedPanel() {
-  const query = useRecentlyPlayedTracks(10);
+  const query = useRecentlyPlayedTracks();
 
   return (
     <ResourceState
@@ -320,20 +314,13 @@ function RecentlyPlayedPanel() {
       emptyLabel="No recent listening history is available right now."
       unavailableLabel="Recently played tracks are unavailable right now."
     >
-      {(items) => (
-        <TrackList
-          prefix="recent-track"
-          tracks={items
-            .map((item) => item.track)
-            .filter((track): track is SpotifyTrack => Boolean(track?.name))}
-        />
-      )}
+      {(tracks) => <TrackList prefix="recent-track" tracks={tracks} />}
     </ResourceState>
   );
 }
 
 function SavedTracksPanel() {
-  const query = useSavedTracks(10);
+  const query = useSavedTracks();
 
   return (
     <ResourceState
@@ -342,20 +329,13 @@ function SavedTracksPanel() {
       emptyLabel="No recently saved tracks are available right now."
       unavailableLabel="Saved tracks are unavailable right now."
     >
-      {(items) => (
-        <TrackList
-          prefix="saved-track"
-          tracks={items
-            .map((item) => item.track)
-            .filter((track): track is SpotifyTrack => Boolean(track?.name))}
-        />
-      )}
+      {(tracks) => <TrackList prefix="saved-track" tracks={tracks} />}
     </ResourceState>
   );
 }
 
 function TopArtistsPanel({ range }: { range: SpotifyTimeRange }) {
-  const query = useTopSpotifyItems('artists', range, 10);
+  const query = useTopSpotifyArtists(range);
 
   return (
     <ResourceState
@@ -370,7 +350,7 @@ function TopArtistsPanel({ range }: { range: SpotifyTimeRange }) {
 }
 
 function SavedPlaylistsPanel() {
-  const query = useUserPlaylists(10);
+  const query = useUserPlaylists();
 
   return (
     <ResourceState
@@ -511,6 +491,14 @@ export default function MusicExperience({
         >
           <SavedPlaylistsPanel />
         </DisclosureSection>
+
+        <p className="music-spotify-privacy">
+          Spotify supplies the music data shown here. Read the{' '}
+          <a className="music-inline-link" href="/spotify-privacy">
+            Spotify privacy notice
+          </a>
+          .
+        </p>
       </section>
 
       <section className="music-cta">

--- a/src/components/music/NowPlayingWidget.tsx
+++ b/src/components/music/NowPlayingWidget.tsx
@@ -1,10 +1,16 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 
 import { useNowPlayingTrack } from '@hooks/useSpotify';
-import { pickSpotifyCoverImage, type SpotifyTrack } from '@utils/spotify';
+import type { SpotifyTrack } from '@utils/spotify';
 
-import { MusicNoteIcon, PauseIcon, PlayIcon, SpotifyIcon } from './icons';
+import { MusicNoteIcon, SpotifyIcon } from './icons';
 import './music.css';
+import {
+  getSpotifyHref,
+  itemFromSeed,
+  PLAYING_INTROS,
+  type WidgetContextLine,
+} from './nowPlaying';
 
 type WidgetMode = 'footer' | 'page';
 
@@ -12,24 +18,6 @@ interface NowPlayingWidgetProps {
   mode?: WidgetMode;
   introSeed?: number;
 }
-
-interface WidgetContextLine {
-  emoji: string;
-  copy: string;
-}
-
-const SPOTIFY_PROFILE =
-  'https://open.spotify.com/user/31yuvamoxkbmkpvhpunh6xwoshii';
-
-export const PLAYING_INTROS: WidgetContextLine[] = [
-  { emoji: '💫', copy: 'vibing to' },
-  { emoji: '🎵', copy: 'listening to' },
-  { emoji: '😇', copy: 'tripping on' },
-  { emoji: '🥰', copy: 'mushing over' },
-  { emoji: '🙈', copy: 'gushing over' },
-  { emoji: '🗣', copy: 'lip syncing to' },
-  { emoji: '👻', copy: 'quietly murmuring' },
-];
 
 const NOT_PLAYING_INTROS: WidgetContextLine[] = [
   { emoji: '🤷🏻‍♀️', copy: "maybe i'm bored of my playlist" },
@@ -41,18 +29,9 @@ const NOT_PLAYING_INTROS: WidgetContextLine[] = [
   { emoji: '🤝🏻', copy: 'maybe i had to stop music to attend a meeting' },
 ];
 
-export function itemFromSeed<T>(items: T[], seed: number) {
-  const index = Math.floor(seed * items.length) % items.length;
-  return items[index] ?? items[0]!;
-}
-
-export function getSpotifyHref(track: SpotifyTrack | null) {
-  return track?.external_urls?.spotify ?? SPOTIFY_PROFILE;
-}
-
 function getWidgetSubtitle(track: SpotifyTrack | null, mode: WidgetMode) {
   if (mode === 'page') {
-    return track?.album?.name ?? 'View Spotify Profile';
+    return track?.albumName ?? 'View Spotify Profile';
   }
 
   return 'Explore Music Page';
@@ -63,61 +42,16 @@ export default function NowPlayingWidget({
   introSeed = 0,
 }: NowPlayingWidgetProps) {
   const query = useNowPlayingTrack();
-  const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const track = query.kind === 'success' ? query.data : null;
   const isUnavailable = query.kind === 'unavailable';
   const isListening = Boolean(track?.name);
   const spotifyHref = getSpotifyHref(track);
-  const albumArt = pickSpotifyCoverImage(track?.album?.images);
+  const albumArt = track?.image ?? null;
   const title = isUnavailable
     ? 'Now playing is unavailable right now.'
     : (track?.name ?? 'Not Playing');
   const subtitle = getWidgetSubtitle(track, mode);
-
-  useEffect(() => {
-    const previousAudio = audioRef.current;
-
-    if (previousAudio) {
-      previousAudio.pause();
-    }
-
-    setIsPreviewPlaying(false);
-
-    if (!track?.preview_url) {
-      audioRef.current = null;
-      return;
-    }
-
-    const audio = new Audio(track.preview_url);
-    // Don't download the 30s preview MP3 until the user actually plays it.
-    audio.preload = 'none';
-    const handleEnded = () => setIsPreviewPlaying(false);
-    audio.addEventListener('ended', handleEnded);
-    audioRef.current = audio;
-
-    return () => {
-      audio.pause();
-      audio.removeEventListener('ended', handleEnded);
-    };
-  }, [track?.preview_url]);
-
-  useEffect(() => {
-    const audio = audioRef.current;
-
-    if (!audio) {
-      return;
-    }
-
-    if (!isPreviewPlaying) {
-      audio.pause();
-      audio.currentTime = 0;
-      return;
-    }
-
-    audio.play().catch(() => setIsPreviewPlaying(false));
-  }, [isPreviewPlaying]);
 
   const introLine = useMemo<WidgetContextLine>(
     () =>
@@ -178,33 +112,19 @@ export default function NowPlayingWidget({
           </span>
         </a>
 
-        {track?.preview_url ? (
-          <button
-            type="button"
-            className="music-now-playing-action"
-            aria-label={
-              isPreviewPlaying ? 'Pause track preview' : 'Play track preview'
-            }
-            aria-pressed={isPreviewPlaying}
-            onClick={() => setIsPreviewPlaying((value) => !value)}
-          >
-            {isPreviewPlaying ? <PauseIcon /> : <PlayIcon />}
-          </button>
-        ) : (
-          <a
-            href={spotifyHref}
-            className="music-now-playing-action music-now-playing-action-link"
-            target="_blank"
-            rel="noreferrer noopener"
-            aria-label={
-              isListening
-                ? `Open ${track?.name} on Spotify`
-                : 'Open Spotify profile'
-            }
-          >
-            <SpotifyIcon />
-          </a>
-        )}
+        <a
+          href={spotifyHref}
+          className="music-now-playing-action music-now-playing-action-link"
+          target="_blank"
+          rel="noreferrer noopener"
+          aria-label={
+            isListening
+              ? `Open ${track?.name} on Spotify`
+              : 'Open Spotify profile'
+          }
+        >
+          <SpotifyIcon />
+        </a>
       </div>
     </div>
   );

--- a/src/components/music/icons.tsx
+++ b/src/components/music/icons.tsx
@@ -36,23 +36,6 @@ export function MusicNoteIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
-export function PauseIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <IconBase {...props}>
-      <path d="M9 6v12" />
-      <path d="M15 6v12" />
-    </IconBase>
-  );
-}
-
-export function PlayIcon(props: SVGProps<SVGSVGElement>) {
-  return (
-    <IconBase {...props}>
-      <path d="m8 6 10 6-10 6Z" fill="currentColor" stroke="none" />
-    </IconBase>
-  );
-}
-
 export function SpotifyIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 168 168" aria-hidden="true" {...props}>

--- a/src/components/music/music.css
+++ b/src/components/music/music.css
@@ -291,6 +291,13 @@
   color: var(--color-light-slate);
 }
 
+.music-spotify-privacy {
+  margin: 40px 10px 0;
+  color: var(--color-slate);
+  font-size: 15px;
+  text-align: center;
+}
+
 .music-cta {
   display: flex;
   flex-direction: column;

--- a/src/components/music/nowPlaying.ts
+++ b/src/components/music/nowPlaying.ts
@@ -1,0 +1,28 @@
+import type { SpotifyTrack } from '@utils/spotify';
+
+export interface WidgetContextLine {
+  emoji: string;
+  copy: string;
+}
+
+const SPOTIFY_PROFILE =
+  'https://open.spotify.com/user/31yuvamoxkbmkpvhpunh6xwoshii';
+
+export const PLAYING_INTROS: WidgetContextLine[] = [
+  { emoji: '💫', copy: 'vibing to' },
+  { emoji: '🎵', copy: 'listening to' },
+  { emoji: '😇', copy: 'tripping on' },
+  { emoji: '🥰', copy: 'mushing over' },
+  { emoji: '🙈', copy: 'gushing over' },
+  { emoji: '🗣', copy: 'lip syncing to' },
+  { emoji: '👻', copy: 'quietly murmuring' },
+];
+
+export function itemFromSeed<T>(items: T[], seed: number) {
+  const index = Math.floor(seed * items.length) % items.length;
+  return items[index] ?? items[0]!;
+}
+
+export function getSpotifyHref(track: SpotifyTrack | null) {
+  return track?.spotifyUrl ?? SPOTIFY_PROFILE;
+}

--- a/src/hooks/useSpotify.ts
+++ b/src/hooks/useSpotify.ts
@@ -2,24 +2,18 @@ import { useCallback, useEffect, useState } from 'react';
 
 import {
   fetchCurrentTrack,
-  fetchCurrentUserPlaylists,
-  fetchCurrentUsersRecentlyPlayed,
-  fetchCurrentUsersSavedTracks,
-  fetchCurrentUsersTopItems,
-  fetchPlaylistById,
-  type SpotifyResult,
+  fetchFavouritePlaylist,
+  fetchRecentlyPlayedTracks,
+  fetchSavedPlaylists,
+  fetchSavedTracks,
+  fetchTopArtists,
+  fetchTopTracks,
   type SpotifyArtist,
   type SpotifyPlaylist,
-  type SpotifyRecentlyPlayedItem,
-  type SpotifySavedTrackItem,
+  type SpotifyResult,
+  type SpotifyTimeRange,
   type SpotifyTrack,
 } from '@utils/spotify';
-
-type SpotifyTimeRange = 'short_term' | 'medium_term' | 'long_term';
-type SpotifyTopItemType = 'artists' | 'tracks';
-type SpotifyTopItem<T extends SpotifyTopItemType> = T extends 'artists'
-  ? SpotifyArtist
-  : SpotifyTrack;
 
 export type SpotifyResourceState<T> = { kind: 'loading' } | SpotifyResult<T>;
 
@@ -42,113 +36,67 @@ function useSpotifyResource<T>(
   return state;
 }
 
-function getUniqueRecentlyPlayedTracks(
-  items: SpotifyRecentlyPlayedItem[],
-): SpotifyRecentlyPlayedItem[] {
-  const seen = new Set<string>();
-
-  return items.filter((item) => {
-    const trackId = item.track?.id;
-
-    if (!trackId || seen.has(trackId)) {
-      return false;
-    }
-
-    seen.add(trackId);
-    return true;
-  });
-}
-
 export function useNowPlayingTrack(): SpotifyResourceState<SpotifyTrack> {
   const fetcher = useCallback(() => fetchCurrentTrack(), []);
 
   return useSpotifyResource(fetcher);
 }
 
-export function useTopSpotifyItems<T extends SpotifyTopItemType>(
-  type: T,
+export function useTopSpotifyTracks(
   timeRange: SpotifyTimeRange,
-  limit = 20,
-): SpotifyResourceState<SpotifyTopItem<T>[]> {
-  const fetcher = useCallback(async (): Promise<
-    SpotifyResult<SpotifyTopItem<T>[]>
-  > => {
-    const response = await fetchCurrentUsersTopItems(type, timeRange, limit);
-
-    if (response.kind !== 'success') {
-      return response;
-    }
-
-    return { kind: 'success', data: response.data.items ?? [] };
-  }, [limit, timeRange, type]);
+): SpotifyResourceState<SpotifyTrack[]> {
+  const fetcher = useCallback(() => fetchTopTracks(timeRange), [timeRange]);
 
   return useSpotifyResource(fetcher);
 }
 
-export function useFavouritePlaylist(
-  playlistId = '3qWhbV6ul3Bfl2iHrN4TYn',
-): SpotifyResourceState<SpotifyPlaylist> {
-  const fetcher = useCallback(
-    () => fetchPlaylistById(playlistId),
-    [playlistId],
-  );
+export function useTopSpotifyArtists(
+  timeRange: SpotifyTimeRange,
+): SpotifyResourceState<SpotifyArtist[]> {
+  const fetcher = useCallback(() => fetchTopArtists(timeRange), [timeRange]);
 
   return useSpotifyResource(fetcher);
 }
 
-export function useRecentlyPlayedTracks(
-  limit = 20,
-): SpotifyResourceState<SpotifyRecentlyPlayedItem[]> {
-  const fetcher = useCallback(async (): Promise<
-    SpotifyResult<SpotifyRecentlyPlayedItem[]>
-  > => {
-    const response = await fetchCurrentUsersRecentlyPlayed(limit);
-
-    if (response.kind !== 'success') {
-      return response;
-    }
-
-    const items = getUniqueRecentlyPlayedTracks(response.data.items ?? []);
-    return items.length > 0
-      ? { kind: 'success', data: items }
-      : { kind: 'empty' };
-  }, [limit]);
+export function useFavouritePlaylist(): SpotifyResourceState<SpotifyPlaylist> {
+  const fetcher = useCallback(() => fetchFavouritePlaylist(), []);
 
   return useSpotifyResource(fetcher);
 }
 
-export function useSavedTracks(
-  limit = 20,
-): SpotifyResourceState<SpotifySavedTrackItem[]> {
+export function useRecentlyPlayedTracks(): SpotifyResourceState<
+  SpotifyTrack[]
+> {
   const fetcher = useCallback(async (): Promise<
-    SpotifyResult<SpotifySavedTrackItem[]>
+    SpotifyResult<SpotifyTrack[]>
   > => {
-    const response = await fetchCurrentUsersSavedTracks(limit);
-
-    if (response.kind !== 'success') {
-      return response;
+    const result = await fetchRecentlyPlayedTracks();
+    if (result.kind !== 'success') {
+      return result;
     }
 
-    return { kind: 'success', data: response.data.items ?? [] };
-  }, [limit]);
+    const seen = new Set<string>();
+    return {
+      kind: 'success',
+      data: result.data.filter((track) => {
+        if (seen.has(track.id)) return false;
+        seen.add(track.id);
+        return true;
+      }),
+    };
+  }, []);
 
   return useSpotifyResource(fetcher);
 }
 
-export function useUserPlaylists(
-  limit = 20,
-): SpotifyResourceState<SpotifyPlaylist[]> {
-  const fetcher = useCallback(async (): Promise<
-    SpotifyResult<SpotifyPlaylist[]>
-  > => {
-    const response = await fetchCurrentUserPlaylists(limit);
+export function useSavedTracks(): SpotifyResourceState<SpotifyTrack[]> {
+  const fetcher = useCallback(() => fetchSavedTracks(), []);
 
-    if (response.kind !== 'success') {
-      return response;
-    }
+  return useSpotifyResource(fetcher);
+}
 
-    return { kind: 'success', data: response.data.items ?? [] };
-  }, [limit]);
+export function useUserPlaylists(): SpotifyResourceState<SpotifyPlaylist[]> {
+  const fetcher = useCallback(() => fetchSavedPlaylists(), []);
 
   return useSpotifyResource(fetcher);
 }

--- a/src/pages/spotify-privacy.astro
+++ b/src/pages/spotify-privacy.astro
@@ -1,0 +1,124 @@
+---
+export const prerender = true;
+
+import PageReveal from '@components/PageReveal.astro';
+import { siteConfig } from '@config/index';
+import BaseLayout from '@layouts/BaseLayout.astro';
+
+const description =
+  'How the Spotify data displayed on Ayush Gupta’s portfolio is accessed, used, and disconnected.';
+---
+
+<BaseLayout title="Spotify Privacy" description={description}>
+  <article class="spotify-privacy-page inline-links">
+    <header class="spotify-privacy-header page-reveal">
+      <h1 class="big-heading">Spotify Privacy</h1>
+      <p class="subtitle">how Spotify data is used on this portfolio</p>
+    </header>
+
+    <div class="spotify-privacy-content page-reveal">
+      <p>
+        This portfolio connects only to Ayush Gupta’s own Spotify account. It
+        uses read-only access to show what Ayush is playing, recently played and
+        saved tracks, top tracks and artists, and selected or saved playlists.
+      </p>
+
+      <h2>What is public</h2>
+      <p>
+        The music page makes small, fixed slices of these categories public.
+        Track, album, artist, and playlist names, artwork, artist names,
+        playlist owners and visible track counts may be displayed. Each item
+        links to its corresponding content on Spotify. No visitor’s Spotify
+        account or listening data is accessed.
+      </p>
+
+      <h2>How the data is used</h2>
+      <p>
+        Spotify remains the source of the displayed metadata and artwork.
+        Responses may be cached temporarily when Spotify permits it, to keep the
+        site reliable and reduce repeated requests. This data is not sold, used
+        to advertise to visitors, or used to build visitor profiles.
+      </p>
+
+      <h2>Disconnecting Spotify</h2>
+      <p>
+        Ayush can disconnect this portfolio from Spotify at any time from the
+        <a
+          href="https://www.spotify.com/account/apps/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          Spotify Apps page
+        </a>
+        by removing the app’s access. Disconnecting stops future Spotify data updates
+        on this site.
+      </p>
+
+      <h2>Contact</h2>
+      <p>
+        Questions about this Spotify integration can be sent to
+        <a href={`mailto:${siteConfig.email}`}>{siteConfig.email}</a>.
+      </p>
+
+      <p class="spotify-privacy-date">Effective: 8 August 2026</p>
+    </div>
+  </article>
+
+  <PageReveal />
+</BaseLayout>
+
+<style>
+  .spotify-privacy-page {
+    width: 100%;
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 100px 0 120px;
+  }
+
+  .spotify-privacy-header {
+    margin-bottom: 70px;
+    text-align: center;
+  }
+
+  .spotify-privacy-content {
+    color: var(--color-light-slate);
+    font-size: 19px;
+    line-height: 1.65;
+  }
+
+  .spotify-privacy-content h2 {
+    margin: 44px 0 12px;
+    color: var(--color-lightest-slate);
+    font-size: 28px;
+    font-weight: 500;
+  }
+
+  .spotify-privacy-content p {
+    margin: 0 0 18px;
+  }
+
+  .spotify-privacy-content a {
+    color: var(--color-green);
+  }
+
+  .spotify-privacy-date {
+    margin-top: 50px !important;
+    color: var(--color-slate);
+    font-family: var(--font-mono);
+    font-size: 13px;
+  }
+
+  @media (max-width: 768px) {
+    .spotify-privacy-page {
+      padding: 80px 0 100px;
+    }
+
+    .spotify-privacy-header {
+      margin-bottom: 50px;
+    }
+
+    .spotify-privacy-content {
+      font-size: 18px;
+    }
+  }
+</style>

--- a/src/utils/spotify.ts
+++ b/src/utils/spotify.ts
@@ -1,4 +1,5 @@
-export const SPOTIFY_PROXY = '/.netlify/functions/spotify';
+export const SPOTIFY_PROXY = '/api/spotify';
+
 const SPOTIFY_FAILURE_BACKOFF_MS = 10_000;
 
 let spotifyBackoffUntil = 0;
@@ -7,6 +8,60 @@ export type SpotifyResult<T> =
   | { kind: 'success'; data: T }
   | { kind: 'empty' }
   | { kind: 'unavailable' };
+
+export type SpotifyTimeRange = 'short_term' | 'medium_term' | 'long_term';
+
+export interface SpotifyImage {
+  url: string;
+  height?: number;
+  width?: number;
+}
+
+export interface SpotifyTrack {
+  id: string;
+  name: string;
+  albumName: string;
+  image: SpotifyImage | null;
+  artists: string[];
+  spotifyUrl: string;
+}
+
+export interface SpotifyArtist {
+  id: string;
+  name: string;
+  image: SpotifyImage | null;
+  genres: string[];
+  spotifyUrl: string;
+}
+
+export interface SpotifyPlaylist {
+  id: string;
+  name: string;
+  image: SpotifyImage | null;
+  ownerName: string | null;
+  trackCount: number | null;
+  spotifyUrl: string;
+}
+
+type SpotifyResource =
+  | 'now-playing'
+  | 'top-tracks'
+  | 'top-artists'
+  | 'favourite-playlist'
+  | 'recently-played'
+  | 'saved-tracks'
+  | 'saved-playlists';
+
+interface SpotifyCacheEntry {
+  result: SpotifyResult<unknown>;
+  expiresAt: number;
+}
+
+const spotifyResponseCache = new Map<string, SpotifyCacheEntry>();
+const spotifyInflightRequests = new Map<
+  string,
+  Promise<SpotifyResult<unknown>>
+>();
 
 function spotifySuccess<T>(data: T): SpotifyResult<T> {
   return { kind: 'success', data };
@@ -20,11 +75,11 @@ function spotifyUnavailable<T>(): SpotifyResult<T> {
   return { kind: 'unavailable' };
 }
 
-function startSpotifyBackoff(): boolean {
+function startSpotifyBackoff(durationMs: number): boolean {
   const now = Date.now();
   const shouldLog = now >= spotifyBackoffUntil;
 
-  spotifyBackoffUntil = now + SPOTIFY_FAILURE_BACKOFF_MS;
+  spotifyBackoffUntil = Math.max(spotifyBackoffUntil, now + durationMs);
   return shouldLog;
 }
 
@@ -37,7 +92,24 @@ function hasSpotifyErrorCode(value: unknown, code: string): boolean {
   );
 }
 
-async function logSpotifyResponseFailure(response: Response) {
+function retryAfterMilliseconds(response: Response): number | null {
+  const retryAfter = response.headers.get('retry-after');
+  if (!retryAfter || !/^[1-9]\d*$/.test(retryAfter)) {
+    return null;
+  }
+
+  const seconds = Number(retryAfter);
+  if (!Number.isSafeInteger(seconds)) {
+    return null;
+  }
+
+  return Math.min(seconds * 1000, Number.MAX_SAFE_INTEGER - Date.now());
+}
+
+async function logSpotifyResponseFailure(
+  response: Response,
+  retryAfterMs: number | null,
+) {
   const body: unknown = await response.json().catch(() => null);
 
   if (hasSpotifyErrorCode(body, 'reauthorization_required')) {
@@ -47,117 +119,57 @@ async function logSpotifyResponseFailure(response: Response) {
     return;
   }
 
+  if (hasSpotifyErrorCode(body, 'rate_limited')) {
+    const retryMessage = retryAfterMs
+      ? ` Retrying is paused for ${Math.ceil(retryAfterMs / 1000)} seconds.`
+      : '';
+    console.warn(`[spotify] Spotify rate limit reached.${retryMessage}`);
+    return;
+  }
+
   console.warn(`[spotify] Request failed with HTTP ${response.status}.`);
 }
 
-interface SpotifyExternalUrls {
-  spotify?: string;
-}
+function responseCacheLifetimeMs(response: Response): number {
+  const cacheControl = response.headers.get('cache-control');
+  if (!cacheControl) {
+    return 0;
+  }
 
-interface SpotifyOwner {
-  display_name?: string;
-}
+  const directives = cacheControl
+    .toLowerCase()
+    .split(',')
+    .map((directive) => directive.trim());
 
-interface SpotifyPagingResponse<T> {
-  items?: T[];
-  href?: string;
-  next?: string | null;
-  total?: number;
-}
+  if (
+    directives.includes('no-store') ||
+    directives.includes('no-cache') ||
+    directives.includes('private')
+  ) {
+    return 0;
+  }
 
-interface SpotifyCurrentTrackResponse {
-  currently_playing_type?: string;
-  item?: SpotifyTrack;
-}
+  const maxAgeDirective = directives.find((directive) =>
+    /^max-age=\d+$/.test(directive),
+  );
+  if (!maxAgeDirective) {
+    return 0;
+  }
 
-type SpotifyTopItemType = 'artists' | 'tracks';
-
-type SpotifyTopItem<T extends SpotifyTopItemType> = T extends 'artists'
-  ? SpotifyArtist
-  : SpotifyTrack;
-
-export interface SpotifyImage {
-  url: string;
-  height?: number | null;
-  width?: number | null;
-}
-
-export interface SpotifyArtist {
-  id?: string;
-  name: string;
-  external_urls?: SpotifyExternalUrls;
-  genres?: string[];
-  images?: SpotifyImage[];
-}
-
-export interface SpotifyAlbum {
-  name?: string;
-  images?: SpotifyImage[];
-}
-
-export interface SpotifyTrack {
-  id?: string;
-  album?: SpotifyAlbum;
-  artists?: SpotifyArtist[];
-  external_urls?: SpotifyExternalUrls;
-  name: string;
-  preview_url?: string | null;
-}
-
-export interface SpotifyRecentlyPlayedItem {
-  track?: SpotifyTrack | null;
-}
-
-export interface SpotifySavedTrackItem {
-  track?: SpotifyTrack | null;
-}
-
-export interface SpotifyPlaylist {
-  id?: string;
-  external_urls?: SpotifyExternalUrls;
-  images?: SpotifyImage[];
-  items?: { total?: number };
-  name: string;
-  owner?: SpotifyOwner;
-  tracks?: { total?: number };
-}
-
-// Module-level cache: survives island remounts and ClientRouter soft
-// navigations, so widgets re-entering the page reuse recent data instead
-// of re-hitting the serverless proxy. In-flight dedupe collapses
-// concurrent identical requests (e.g. hero + footer now-playing).
-const SPOTIFY_NOW_PLAYING_TTL_MS = 30_000;
-const SPOTIFY_LIBRARY_TTL_MS = 5 * 60_000;
-
-interface SpotifyCacheEntry {
-  result: SpotifyResult<unknown>;
-  expiresAt: number;
-}
-
-const spotifyResponseCache = new Map<string, SpotifyCacheEntry>();
-const spotifyInflightRequests = new Map<
-  string,
-  Promise<SpotifyResult<unknown>>
->();
-
-function cacheTtlForPath(path: string): number {
-  return path === '/me/player/currently-playing'
-    ? SPOTIFY_NOW_PLAYING_TTL_MS
-    : SPOTIFY_LIBRARY_TTL_MS;
+  const seconds = Number(maxAgeDirective.slice('max-age='.length));
+  return Number.isSafeInteger(seconds) && seconds > 0 ? seconds * 1000 : 0;
 }
 
 async function spotifyGet<T>(
-  path: string,
-  params: Record<string, string | number> = {},
+  resource: SpotifyResource,
+  params: { range?: SpotifyTimeRange } = {},
 ): Promise<SpotifyResult<T>> {
-  const qs = new URLSearchParams({
-    path,
-    ...Object.fromEntries(
-      Object.entries(params).map(([key, value]) => [key, String(value)]),
-    ),
-  });
-  const cacheKey = qs.toString();
+  const query = new URLSearchParams({ resource });
+  if (params.range) {
+    query.set('range', params.range);
+  }
 
+  const cacheKey = query.toString();
   const cached = spotifyResponseCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.result as SpotifyResult<T>;
@@ -174,34 +186,36 @@ async function spotifyGet<T>(
 
   const request = (async (): Promise<SpotifyResult<T>> => {
     try {
-      const response = await fetch(`${SPOTIFY_PROXY}?${qs.toString()}`, {
-        headers: {
-          Accept: 'application/json',
-        },
+      const response = await fetch(`${SPOTIFY_PROXY}?${query}`, {
+        headers: { Accept: 'application/json' },
       });
 
       if (!response.ok) {
-        if (startSpotifyBackoff()) {
-          await logSpotifyResponseFailure(response);
+        const retryAfterMs = retryAfterMilliseconds(response);
+        const backoffMs = retryAfterMs ?? SPOTIFY_FAILURE_BACKOFF_MS;
+        if (startSpotifyBackoff(backoffMs)) {
+          await logSpotifyResponseFailure(response, retryAfterMs);
         }
         return spotifyUnavailable();
       }
 
       const result =
-        response.status === 204 || response.status === 202
+        response.status === 204
           ? spotifyEmpty<T>()
           : spotifySuccess((await response.json()) as T);
 
       spotifyBackoffUntil = 0;
-      // Cache 204s too ("nothing playing" is a valid, reusable answer).
-      spotifyResponseCache.set(cacheKey, {
-        result,
-        expiresAt: Date.now() + cacheTtlForPath(path),
-      });
+      const cacheLifetime = responseCacheLifetimeMs(response);
+      if (cacheLifetime > 0) {
+        spotifyResponseCache.set(cacheKey, {
+          result,
+          expiresAt: Date.now() + cacheLifetime,
+        });
+      }
 
       return result;
     } catch (error) {
-      if (startSpotifyBackoff()) {
+      if (startSpotifyBackoff(SPOTIFY_FAILURE_BACKOFF_MS)) {
         console.warn(
           '[spotify] Request failed before Spotify responded.',
           error,
@@ -220,122 +234,60 @@ async function spotifyGet<T>(
   }
 }
 
-export async function fetchCurrentTrack(): Promise<
-  SpotifyResult<SpotifyTrack>
+async function spotifyCollection<T>(
+  resource: SpotifyResource,
+  params: { range?: SpotifyTimeRange } = {},
+): Promise<SpotifyResult<T[]>> {
+  const result = await spotifyGet<T[]>(resource, params);
+
+  if (result.kind !== 'success') {
+    return result;
+  }
+
+  if (!Array.isArray(result.data)) {
+    if (startSpotifyBackoff(SPOTIFY_FAILURE_BACKOFF_MS)) {
+      console.warn('[spotify] Response shape was invalid.');
+    }
+    return spotifyUnavailable();
+  }
+
+  return result.data.length > 0 ? result : spotifyEmpty();
+}
+
+export function fetchCurrentTrack(): Promise<SpotifyResult<SpotifyTrack>> {
+  return spotifyGet('now-playing');
+}
+
+export function fetchFavouritePlaylist(): Promise<
+  SpotifyResult<SpotifyPlaylist>
 > {
-  const result = await spotifyGet<SpotifyCurrentTrackResponse>(
-    '/me/player/currently-playing',
-  );
-
-  if (result.kind !== 'success') {
-    return result;
-  }
-
-  const { data } = result;
-
-  if (data.currently_playing_type === 'track' && data.item) {
-    return spotifySuccess(data.item);
-  }
-
-  return spotifyEmpty();
+  return spotifyGet('favourite-playlist');
 }
 
-export async function fetchPlaylistById(
-  playlistId: string,
-): Promise<SpotifyResult<SpotifyPlaylist>> {
-  return spotifyGet<SpotifyPlaylist>(`/playlists/${playlistId}`);
+export function fetchTopTracks(
+  range: SpotifyTimeRange,
+): Promise<SpotifyResult<SpotifyTrack[]>> {
+  return spotifyCollection('top-tracks', { range });
 }
 
-export async function fetchCurrentUserPlaylists(
-  limit = 20,
-): Promise<SpotifyResult<SpotifyPagingResponse<SpotifyPlaylist>>> {
-  const result = await spotifyGet<SpotifyPagingResponse<SpotifyPlaylist>>(
-    '/me/playlists',
-    { limit },
-  );
-
-  if (result.kind !== 'success') {
-    return result;
-  }
-
-  if (result.data.items?.length) {
-    return result;
-  }
-
-  return spotifyEmpty();
+export function fetchTopArtists(
+  range: SpotifyTimeRange,
+): Promise<SpotifyResult<SpotifyArtist[]>> {
+  return spotifyCollection('top-artists', { range });
 }
 
-export async function fetchCurrentUsersRecentlyPlayed(
-  limit = 20,
-): Promise<SpotifyResult<SpotifyPagingResponse<SpotifyRecentlyPlayedItem>>> {
-  const result = await spotifyGet<
-    SpotifyPagingResponse<SpotifyRecentlyPlayedItem>
-  >('/me/player/recently-played', { limit });
-
-  if (result.kind !== 'success') {
-    return result;
-  }
-
-  if (result.data.items?.length) {
-    return result;
-  }
-
-  return spotifyEmpty();
+export function fetchRecentlyPlayedTracks(): Promise<
+  SpotifyResult<SpotifyTrack[]>
+> {
+  return spotifyCollection('recently-played');
 }
 
-export async function fetchCurrentUsersSavedTracks(
-  limit = 20,
-): Promise<SpotifyResult<SpotifyPagingResponse<SpotifySavedTrackItem>>> {
-  const result = await spotifyGet<SpotifyPagingResponse<SpotifySavedTrackItem>>(
-    '/me/tracks',
-    { limit },
-  );
-
-  if (result.kind !== 'success') {
-    return result;
-  }
-
-  if (result.data.items?.length) {
-    return result;
-  }
-
-  return spotifyEmpty();
+export function fetchSavedTracks(): Promise<SpotifyResult<SpotifyTrack[]>> {
+  return spotifyCollection('saved-tracks');
 }
 
-export async function fetchCurrentUsersTopItems<T extends SpotifyTopItemType>(
-  type: T,
-  timeRange: 'short_term' | 'medium_term' | 'long_term' = 'short_term',
-  limit = 20,
-): Promise<SpotifyResult<SpotifyPagingResponse<SpotifyTopItem<T>>>> {
-  const result = await spotifyGet<SpotifyPagingResponse<SpotifyTopItem<T>>>(
-    `/me/top/${type}`,
-    { time_range: timeRange, limit },
-  );
-
-  if (result.kind !== 'success') {
-    return result;
-  }
-
-  if (result.data.items?.length) {
-    return result;
-  }
-
-  return spotifyEmpty();
-}
-
-export function pickSpotifyCoverImage(
-  images?: SpotifyImage[] | null,
-): SpotifyImage | null {
-  if (!Array.isArray(images) || images.length === 0) {
-    return null;
-  }
-
-  return images[1] ?? images[0] ?? null;
-}
-
-export function getPlaylistTrackTotal(
-  playlist?: Pick<SpotifyPlaylist, 'items' | 'tracks'> | null,
-): number | null {
-  const total = playlist?.items?.total ?? playlist?.tracks?.total;
-  return typeof total === 'number' ? total : null;
+export function fetchSavedPlaylists(): Promise<
+  SpotifyResult<SpotifyPlaylist[]>
+> {
+  return spotifyCollection('saved-playlists');
 }

--- a/test/spotify-client.test.mjs
+++ b/test/spotify-client.test.mjs
@@ -3,24 +3,101 @@ import { afterEach, test } from 'node:test';
 
 const originalFetch = globalThis.fetch;
 const originalConsoleWarn = console.warn;
+const originalDateNow = Date.now;
 let moduleVersion = 0;
+
+const track = {
+  id: 'track-1',
+  name: 'Track One',
+  albumName: 'Album One',
+  image: { url: 'https://i.scdn.co/track.jpg', width: 300, height: 300 },
+  artists: ['Artist One'],
+  spotifyUrl: 'https://open.spotify.com/track/track-1',
+};
+
+const artist = {
+  id: 'artist-1',
+  name: 'Artist One',
+  image: { url: 'https://i.scdn.co/artist.jpg', width: 300, height: 300 },
+  genres: ['indie'],
+  spotifyUrl: 'https://open.spotify.com/artist/artist-1',
+};
+
+const playlist = {
+  id: 'playlist-1',
+  name: 'Playlist One',
+  image: { url: 'https://i.scdn.co/playlist.jpg', width: 300, height: 300 },
+  ownerName: 'Ayush',
+  trackCount: 10,
+  spotifyUrl: 'https://open.spotify.com/playlist/playlist-1',
+};
 
 async function loadSpotifyClient() {
   moduleVersion += 1;
   return import(`../src/utils/spotify.ts?test=${moduleVersion}`);
 }
 
-function mockSpotifyResponse(body, status = 200) {
-  globalThis.fetch = async () =>
-    new Response(body == null ? null : JSON.stringify(body), {
-      status,
-      headers: { 'Content-Type': 'application/json' },
-    });
+function spotifyResponse(body, status = 200, headers = {}) {
+  return new Response(body == null ? null : JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      ...headers,
+    },
+  });
 }
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   console.warn = originalConsoleWarn;
+  Date.now = originalDateNow;
+});
+
+test('requests only fixed presentation resources without an origin secret', async () => {
+  const spotify = await loadSpotifyClient();
+  const calls = [];
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url: String(url), options });
+    const resource = new URL(
+      String(url),
+      'https://ayushgupta.tech',
+    ).searchParams.get('resource');
+
+    if (resource === 'now-playing') return spotifyResponse(track);
+    if (resource === 'favourite-playlist') return spotifyResponse(playlist);
+    if (resource === 'top-artists') return spotifyResponse([artist]);
+    if (resource === 'saved-playlists') return spotifyResponse([playlist]);
+    return spotifyResponse([track]);
+  };
+
+  await spotify.fetchCurrentTrack();
+  await spotify.fetchTopTracks('short_term');
+  await spotify.fetchTopArtists('long_term');
+  await spotify.fetchFavouritePlaylist();
+  await spotify.fetchRecentlyPlayedTracks();
+  await spotify.fetchSavedTracks();
+  await spotify.fetchSavedPlaylists();
+
+  assert.deepEqual(
+    calls.map(({ url }) => url),
+    [
+      '/api/spotify?resource=now-playing',
+      '/api/spotify?resource=top-tracks&range=short_term',
+      '/api/spotify?resource=top-artists&range=long_term',
+      '/api/spotify?resource=favourite-playlist',
+      '/api/spotify?resource=recently-played',
+      '/api/spotify?resource=saved-tracks',
+      '/api/spotify?resource=saved-playlists',
+    ],
+  );
+  assert.ok(
+    calls.every(({ options }) =>
+      Object.keys(options.headers).every(
+        (header) => header.toLowerCase() !== 'x-spotify-origin-key',
+      ),
+    ),
+  );
 });
 
 test('keeps Spotify empty, successful, and unavailable results distinct', async (t) => {
@@ -28,7 +105,7 @@ test('keeps Spotify empty, successful, and unavailable results distinct', async 
     'treats a no-content now-playing response as empty',
     async () => {
       const spotify = await loadSpotifyClient();
-      mockSpotifyResponse(null, 204);
+      globalThis.fetch = async () => spotifyResponse(null, 204);
 
       assert.deepEqual(await spotify.fetchCurrentTrack(), { kind: 'empty' });
     },
@@ -36,32 +113,45 @@ test('keeps Spotify empty, successful, and unavailable results distinct', async 
 
   await t.test('treats a valid empty collection as empty', async () => {
     const spotify = await loadSpotifyClient();
-    mockSpotifyResponse({ items: [] });
+    globalThis.fetch = async () => spotifyResponse([]);
 
-    assert.deepEqual(await spotify.fetchCurrentUsersTopItems('tracks'), {
+    assert.deepEqual(await spotify.fetchTopTracks('short_term'), {
       kind: 'empty',
     });
   });
 
   await t.test('keeps populated collections successful', async () => {
     const spotify = await loadSpotifyClient();
-    mockSpotifyResponse({ items: [{ name: 'A track' }] });
+    globalThis.fetch = async () => spotifyResponse([track]);
 
-    assert.deepEqual(await spotify.fetchCurrentUsersTopItems('tracks'), {
+    assert.deepEqual(await spotify.fetchTopTracks('medium_term'), {
       kind: 'success',
-      data: { items: [{ name: 'A track' }] },
+      data: [track],
     });
   });
+
+  await t.test(
+    'treats a malformed successful collection as unavailable',
+    async () => {
+      const spotify = await loadSpotifyClient();
+      globalThis.fetch = async () => spotifyResponse({ items: [track] });
+      console.warn = () => {};
+
+      assert.deepEqual(await spotify.fetchTopTracks('short_term'), {
+        kind: 'unavailable',
+      });
+    },
+  );
 
   await t.test(
     'treats generic and reauthorization failures as unavailable',
     async () => {
       for (const [status, body] of [
-        [502, { error: 'Failed to proxy Spotify request' }],
+        [502, { error: 'upstream_failure' }],
         [503, { error: 'reauthorization_required' }],
       ]) {
         const spotify = await loadSpotifyClient();
-        mockSpotifyResponse(body, status);
+        globalThis.fetch = async () => spotifyResponse(body, status);
         console.warn = () => {};
 
         assert.deepEqual(await spotify.fetchCurrentTrack(), {
@@ -70,4 +160,144 @@ test('keeps Spotify empty, successful, and unavailable results distinct', async 
       }
     },
   );
+});
+
+test('uses the proxy cache lifetime for module caching', async (t) => {
+  await t.test('reuses a response only inside its max-age', async () => {
+    let now = 1_000_000;
+    let fetchCount = 0;
+    Date.now = () => now;
+    const spotify = await loadSpotifyClient();
+    globalThis.fetch = async () => {
+      fetchCount += 1;
+      return spotifyResponse([track], 200, {
+        'Cache-Control': 'public, max-age=2',
+      });
+    };
+
+    await spotify.fetchSavedTracks();
+    now += 1_999;
+    await spotify.fetchSavedTracks();
+    assert.equal(fetchCount, 1);
+
+    now += 2;
+    await spotify.fetchSavedTracks();
+    assert.equal(fetchCount, 2);
+  });
+
+  await t.test('does not module-cache a no-store response', async () => {
+    let fetchCount = 0;
+    const spotify = await loadSpotifyClient();
+    globalThis.fetch = async () => {
+      fetchCount += 1;
+      return spotifyResponse([track]);
+    };
+
+    await spotify.fetchSavedTracks();
+    await spotify.fetchSavedTracks();
+    assert.equal(fetchCount, 2);
+  });
+
+  await t.test('can cache a genuine 204 empty response', async () => {
+    let fetchCount = 0;
+    const spotify = await loadSpotifyClient();
+    globalThis.fetch = async () => {
+      fetchCount += 1;
+      return spotifyResponse(null, 204, {
+        'Cache-Control': 'public, max-age=30',
+      });
+    };
+
+    assert.deepEqual(await spotify.fetchCurrentTrack(), { kind: 'empty' });
+    assert.deepEqual(await spotify.fetchCurrentTrack(), { kind: 'empty' });
+    assert.equal(fetchCount, 1);
+  });
+});
+
+test('honors Retry-After without automatically retrying', async () => {
+  let now = 2_000_000;
+  let fetchCount = 0;
+  let warningCount = 0;
+  Date.now = () => now;
+  console.warn = () => {
+    warningCount += 1;
+  };
+  const spotify = await loadSpotifyClient();
+  globalThis.fetch = async () => {
+    fetchCount += 1;
+    if (fetchCount === 1) {
+      return spotifyResponse({ error: 'rate_limited' }, 429, {
+        'Retry-After': '30',
+      });
+    }
+    return spotifyResponse([track]);
+  };
+
+  assert.deepEqual(await spotify.fetchSavedTracks(), { kind: 'unavailable' });
+  assert.equal(fetchCount, 1);
+  assert.equal(warningCount, 1);
+
+  now += 29_999;
+  assert.deepEqual(await spotify.fetchTopTracks('short_term'), {
+    kind: 'unavailable',
+  });
+  assert.equal(fetchCount, 1);
+  assert.equal(warningCount, 1);
+
+  now += 1;
+  assert.deepEqual(await spotify.fetchTopTracks('short_term'), {
+    kind: 'success',
+    data: [track],
+  });
+  assert.equal(fetchCount, 2);
+});
+
+test('uses the ten-second fallback backoff when Retry-After is absent', async () => {
+  let now = 3_000_000;
+  let fetchCount = 0;
+  Date.now = () => now;
+  console.warn = () => {};
+  const spotify = await loadSpotifyClient();
+  globalThis.fetch = async () => {
+    fetchCount += 1;
+    return fetchCount === 1
+      ? spotifyResponse({ error: 'upstream_failure' }, 502)
+      : spotifyResponse(track);
+  };
+
+  await spotify.fetchCurrentTrack();
+  now += 9_999;
+  await spotify.fetchCurrentTrack();
+  assert.equal(fetchCount, 1);
+
+  now += 1;
+  assert.deepEqual(await spotify.fetchCurrentTrack(), {
+    kind: 'success',
+    data: track,
+  });
+  assert.equal(fetchCount, 2);
+});
+
+test('deduplicates identical in-flight requests', async () => {
+  const spotify = await loadSpotifyClient();
+  let resolveResponse;
+  let fetchCount = 0;
+  globalThis.fetch = () => {
+    fetchCount += 1;
+    return new Promise((resolve) => {
+      resolveResponse = resolve;
+    });
+  };
+
+  const first = spotify.fetchCurrentTrack();
+  const second = spotify.fetchCurrentTrack();
+  resolveResponse(
+    spotifyResponse(track, 200, {
+      'Cache-Control': 'public, max-age=30',
+    }),
+  );
+
+  assert.deepEqual(await first, { kind: 'success', data: track });
+  assert.deepEqual(await second, { kind: 'success', data: track });
+  assert.equal(fetchCount, 1);
 });

--- a/test/spotify-proxy.test.cjs
+++ b/test/spotify-proxy.test.cjs
@@ -4,68 +4,691 @@ const assert = require('node:assert/strict');
 const functionPath = require.resolve('../netlify/functions/spotify.cjs');
 const originalFetch = globalThis.fetch;
 const originalConsoleError = console.error;
-const originalEnvironment = {
-  clientId: process.env.SPOTIFY_CLIENT_ID,
-  clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
-  refreshToken: process.env.SPOTIFY_REFRESH_TOKEN,
-};
+const environmentNames = [
+  'SPOTIFY_LOCAL_DEV_BYPASS',
+  'SPOTIFY_CLIENT_ID',
+  'SPOTIFY_CLIENT_SECRET',
+  'SPOTIFY_REFRESH_TOKEN',
+  'SPOTIFY_ORIGIN_KEY_CURRENT',
+  'SPOTIFY_ORIGIN_KEY_NEXT',
+];
+const originalEnvironment = Object.fromEntries(
+  environmentNames.map((name) => [name, process.env[name]]),
+);
 
-function loadHandler(tokenError) {
+function restoreEnvironment() {
+  for (const [name, value] of Object.entries(originalEnvironment)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+}
+
+function spotifyTrack(id = 'track-1') {
+  return {
+    id,
+    name: `Track ${id}`,
+    album: {
+      name: `Album ${id}`,
+      href: 'https://api.spotify.com/v1/albums/private',
+      images: [
+        { url: 'https://i.scdn.co/large.jpg', width: 640, height: 640 },
+        { url: 'https://i.scdn.co/medium.jpg', width: 300, height: 300 },
+      ],
+    },
+    artists: [
+      {
+        id: 'artist-1',
+        name: 'Artist One',
+        href: 'https://api.spotify.com/v1/artists/private',
+      },
+    ],
+    external_urls: { spotify: `https://open.spotify.com/track/${id}` },
+    href: `https://api.spotify.com/v1/tracks/${id}`,
+    preview_url: 'https://audio.example/preview.mp3',
+    uri: `spotify:track:${id}`,
+  };
+}
+
+function spotifyArtist(id = 'artist-1') {
+  return {
+    id,
+    name: `Artist ${id}`,
+    external_urls: { spotify: `https://open.spotify.com/artist/${id}` },
+    genres: ['indie', 'folk'],
+    href: `https://api.spotify.com/v1/artists/${id}`,
+    images: [{ url: 'https://i.scdn.co/artist.jpg', width: 320, height: 320 }],
+    popularity: 99,
+    uri: `spotify:artist:${id}`,
+  };
+}
+
+function spotifyPlaylist(id = 'playlist-1') {
+  return {
+    id,
+    name: `Playlist ${id}`,
+    external_urls: { spotify: `https://open.spotify.com/playlist/${id}` },
+    href: `https://api.spotify.com/v1/playlists/${id}`,
+    images: [
+      { url: 'https://mosaic.scdn.co/large.jpg', width: 640, height: 640 },
+      { url: 'https://mosaic.scdn.co/medium.jpg', width: 300, height: 300 },
+    ],
+    owner: { display_name: 'Ayush', id: 'private-owner-id' },
+    tracks: { total: 42, href: 'https://api.spotify.com/private-tracks' },
+    collaborative: false,
+    public: false,
+  };
+}
+
+function payloadFor(resource) {
+  switch (resource) {
+    case 'now-playing':
+      return {
+        currently_playing_type: 'track',
+        item: spotifyTrack(),
+        progress_ms: 12345,
+        device: { id: 'private-device' },
+      };
+    case 'top-tracks':
+      return {
+        items: [spotifyTrack()],
+        href: 'https://api.spotify.com/private-page',
+        next: 'https://api.spotify.com/private-next',
+        total: 500,
+      };
+    case 'top-artists':
+      return { items: [spotifyArtist()], total: 500 };
+    case 'favourite-playlist':
+      return spotifyPlaylist('3qWhbV6ul3Bfl2iHrN4TYn');
+    case 'recently-played':
+      return {
+        items: [{ track: spotifyTrack(), played_at: '2026-08-08T00:00:00Z' }],
+        cursors: { after: 'private-cursor' },
+      };
+    case 'saved-tracks':
+      return {
+        items: [{ track: spotifyTrack(), added_at: '2026-08-08T00:00:00Z' }],
+        next: 'https://api.spotify.com/private-next',
+      };
+    case 'saved-playlists':
+      return { items: [spotifyPlaylist()], total: 100 };
+    default:
+      throw new Error(`No fixture for ${resource}`);
+  }
+}
+
+function jsonResponse(body, status = 200, headers = {}) {
+  return new Response(body === null ? null : JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+  });
+}
+
+function loadSpotifyFunction({
+  apiResponse,
+  local = true,
+  originCurrent,
+  originNext,
+  tokenResponse,
+} = {}) {
+  restoreEnvironment();
   process.env.SPOTIFY_CLIENT_ID = 'client-id';
   process.env.SPOTIFY_CLIENT_SECRET = 'client-secret';
   process.env.SPOTIFY_REFRESH_TOKEN = 'refresh-token';
-  globalThis.fetch = async () =>
-    new Response(JSON.stringify(tokenError), {
-      status: 400,
-      headers: { 'Content-Type': 'application/json' },
-    });
+
+  if (local) process.env.SPOTIFY_LOCAL_DEV_BYPASS = 'true';
+  else delete process.env.SPOTIFY_LOCAL_DEV_BYPASS;
+  if (originCurrent) process.env.SPOTIFY_ORIGIN_KEY_CURRENT = originCurrent;
+  else delete process.env.SPOTIFY_ORIGIN_KEY_CURRENT;
+  if (originNext) process.env.SPOTIFY_ORIGIN_KEY_NEXT = originNext;
+  else delete process.env.SPOTIFY_ORIGIN_KEY_NEXT;
+
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+
+    if (String(url) === 'https://accounts.spotify.com/api/token') {
+      if (typeof tokenResponse === 'function') {
+        return tokenResponse(
+          calls.filter((call) => call.url.includes('/api/token')).length,
+        );
+      }
+      return (
+        tokenResponse ??
+        jsonResponse({ access_token: 'access-token', expires_in: 3600 })
+      );
+    }
+
+    if (typeof apiResponse === 'function') {
+      return apiResponse(url, options);
+    }
+    return (
+      apiResponse ??
+      jsonResponse(payloadFor('top-tracks'), 200, {
+        'Cache-Control': 'public, max-age=600',
+      })
+    );
+  };
   console.error = () => {};
   delete require.cache[functionPath];
 
-  return require(functionPath).handler;
+  const spotifyFunction = require(functionPath);
+
+  return {
+    config: spotifyFunction.config,
+    defaultHandler: spotifyFunction.default,
+    handler: spotifyFunction.testHandler,
+    reservedHandler: spotifyFunction.handler,
+    calls,
+  };
+}
+
+function eventFor(query, { headers = {}, method = 'GET', raw = true } = {}) {
+  const search = new URLSearchParams(query);
+  const event = {
+    httpMethod: method,
+    headers,
+    queryStringParameters: Object.fromEntries(search),
+  };
+  if (raw) {
+    event.rawUrl = `https://ayushgupta.tech/api/spotify?${search}`;
+  }
+  return event;
 }
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
   console.error = originalConsoleError;
-  for (const [key, value] of Object.entries({
-    SPOTIFY_CLIENT_ID: originalEnvironment.clientId,
-    SPOTIFY_CLIENT_SECRET: originalEnvironment.clientSecret,
-    SPOTIFY_REFRESH_TOKEN: originalEnvironment.refreshToken,
-  })) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
-  }
+  restoreEnvironment();
   delete require.cache[functionPath];
 });
 
-test('reports a safe reauthorization error when Spotify revokes the refresh token', async () => {
-  const handler = loadHandler({ error: 'invalid_grant' });
+test('exports a v2 function with a path-scoped Netlify rate limit', () => {
+  const { config, defaultHandler, reservedHandler } = loadSpotifyFunction();
 
-  const response = await handler({
-    httpMethod: 'GET',
-    queryStringParameters: { path: '/me/top/tracks' },
+  assert.equal(typeof defaultHandler, 'function');
+  assert.equal(reservedHandler, undefined);
+  assert.deepEqual(config, {
+    path: '/api/spotify',
+    rateLimit: {
+      action: 'rate_limit',
+      aggregateBy: ['ip', 'domain'],
+      windowLimit: 30,
+      windowSize: 60,
+    },
   });
+});
+
+test('maps every public resource to one fixed Spotify request', async () => {
+  const cases = [
+    ['now-playing', undefined, '/me/player/currently-playing'],
+    [
+      'top-tracks',
+      'short_term',
+      '/me/top/tracks?time_range=short_term&limit=10',
+    ],
+    [
+      'top-artists',
+      'long_term',
+      '/me/top/artists?time_range=long_term&limit=10',
+    ],
+    ['favourite-playlist', undefined, '/playlists/3qWhbV6ul3Bfl2iHrN4TYn'],
+    ['recently-played', undefined, '/me/player/recently-played?limit=10'],
+    ['saved-tracks', undefined, '/me/tracks?limit=10'],
+    ['saved-playlists', undefined, '/me/playlists?limit=10'],
+  ];
+
+  for (const [resource, range, expectedPath] of cases) {
+    const { handler, calls } = loadSpotifyFunction({
+      apiResponse: jsonResponse(payloadFor(resource), 200, {
+        'Cache-Control': 'public, max-age=600',
+      }),
+    });
+    const query = range ? { resource, range } : { resource };
+    const response = await handler(eventFor(query));
+
+    assert.equal(response.statusCode, 200, resource);
+    assert.equal(calls.length, 2, resource);
+    assert.equal(calls[1].url, `https://api.spotify.com/v1${expectedPath}`);
+    assert.equal(calls[1].options.headers.Authorization, 'Bearer access-token');
+  }
+});
+
+test('rejects malformed, duplicate, unknown, and incompatible parameters before Spotify', async () => {
+  const invalidQueries = [
+    '',
+    'resource=unknown',
+    'resource=top-tracks',
+    'resource=top-tracks&range=invalid',
+    'resource=top-tracks&range=short_term&range=long_term',
+    'resource=now-playing&range=short_term',
+    'resource=now-playing&limit=10',
+    'resource=now-playing&path=%2Fme%2Ftracks',
+    'resource=now-playing&resource=saved-tracks',
+  ];
+
+  for (const rawQuery of invalidQueries) {
+    const { handler, calls } = loadSpotifyFunction();
+    const response = await handler({
+      httpMethod: 'GET',
+      headers: {},
+      rawUrl: `https://ayushgupta.tech/api/spotify?${rawQuery}`,
+      queryStringParameters: Object.fromEntries(new URLSearchParams(rawQuery)),
+    });
+
+    assert.equal(response.statusCode, 400, rawQuery);
+    assert.deepEqual(JSON.parse(response.body), { error: 'invalid_request' });
+    assert.equal(calls.length, 0, rawQuery);
+  }
+});
+
+test('allows only GET and returns defensive response headers', async () => {
+  const { handler, calls } = loadSpotifyFunction({ local: false });
+  const response = await handler(eventFor({}, { method: 'POST' }));
+
+  assert.equal(response.statusCode, 405);
+  assert.equal(response.headers.Allow, 'GET');
+  assert.equal(response.headers['Content-Type'], 'application/json');
+  assert.equal(response.headers['X-Content-Type-Options'], 'nosniff');
+  assert.equal(response.headers['Cache-Control'], 'no-store');
+  assert.equal(
+    response.headers['Netlify-Vary'],
+    'query,header=X-Spotify-Origin-Key',
+  );
+  assert.equal(calls.length, 0);
+});
+
+test('fails closed and accepts only current or next origin keys outside Netlify Dev', async () => {
+  const currentKey = 'current-origin-key-12345678901234567890';
+  const nextKey = 'next-origin-key-123456789012345678901234';
+  const noConfig = loadSpotifyFunction({ local: false });
+  const noConfigResponse = await noConfig.handler(
+    eventFor({ resource: 'now-playing' }),
+  );
+  assert.equal(noConfigResponse.statusCode, 503);
+  assert.deepEqual(JSON.parse(noConfigResponse.body), {
+    error: 'configuration_error',
+  });
+  assert.equal(noConfig.calls.length, 0);
+
+  for (const [label, suppliedKey, expectedStatus] of [
+    ['missing', undefined, 403],
+    ['incorrect', 'wrong-key', 403],
+    ['current', currentKey, 200],
+    ['next', nextKey, 200],
+  ]) {
+    const { handler, calls } = loadSpotifyFunction({
+      local: false,
+      originCurrent: currentKey,
+      originNext: nextKey,
+      apiResponse: jsonResponse(payloadFor('top-tracks'), 200, {
+        'Cache-Control': 'public, max-age=60',
+      }),
+    });
+    const headers = suppliedKey ? { 'X-Spotify-Origin-Key': suppliedKey } : {};
+    const response = await handler(
+      eventFor({ resource: 'top-tracks', range: 'short_term' }, { headers }),
+    );
+
+    assert.equal(response.statusCode, expectedStatus, label);
+    assert.equal(calls.length, expectedStatus === 200 ? 2 : 0, label);
+    assert.equal(response.body.includes(suppliedKey ?? currentKey), false);
+  }
+});
+
+test('rejects short origin keys as unsafe configuration', async () => {
+  const { handler, calls } = loadSpotifyFunction({
+    local: false,
+    originCurrent: 'too-short',
+  });
+
+  const response = await handler(
+    eventFor(
+      { resource: 'now-playing' },
+      { headers: { 'X-Spotify-Origin-Key': 'too-short' } },
+    ),
+  );
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(JSON.parse(response.body), { error: 'configuration_error' });
+  assert.equal(calls.length, 0);
+});
+
+test('local bypass requires the explicit local-only marker', async () => {
+  const local = loadSpotifyFunction({
+    apiResponse: jsonResponse(payloadFor('now-playing'), 200, {
+      'Cache-Control': 'public, max-age=30',
+    }),
+  });
+
+  const response = await local.handler(eventFor({ resource: 'now-playing' }));
+  assert.equal(response.statusCode, 200);
+});
+
+test('v2 entrypoint accepts Netlify local context and returns a web Response', async () => {
+  const { defaultHandler } = loadSpotifyFunction({
+    local: false,
+    apiResponse: jsonResponse(payloadFor('now-playing'), 200, {
+      'Cache-Control': 'public, max-age=30',
+    }),
+  });
+  const response = await defaultHandler(
+    new Request('https://ayushgupta.tech/api/spotify?resource=now-playing'),
+    { deploy: { context: 'dev' } },
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
+  assert.equal(
+    (await response.json()).spotifyUrl,
+    'https://open.spotify.com/track/track-1',
+  );
+});
+
+test('a deployed Netlify context cannot use the local bypass marker', async () => {
+  const { defaultHandler, calls } = loadSpotifyFunction({ local: true });
+  const response = await defaultHandler(
+    new Request('https://ayushgupta.tech/api/spotify?resource=now-playing'),
+    { deploy: { context: 'production' } },
+  );
+
+  assert.equal(response.status, 503);
+  assert.deepEqual(await response.json(), { error: 'configuration_error' });
+  assert.equal(calls.length, 0);
+});
+
+test('returns purpose-built DTOs without private Spotify fields or preview audio', async (t) => {
+  await t.test('track DTO', async () => {
+    const { handler } = loadSpotifyFunction({
+      apiResponse: jsonResponse(payloadFor('top-tracks'), 200, {
+        'Cache-Control': 'public, max-age=60',
+      }),
+    });
+    const response = await handler(
+      eventFor({ resource: 'top-tracks', range: 'short_term' }),
+    );
+
+    assert.deepEqual(JSON.parse(response.body), [
+      {
+        id: 'track-1',
+        name: 'Track track-1',
+        albumName: 'Album track-1',
+        image: {
+          url: 'https://i.scdn.co/medium.jpg',
+          width: 300,
+          height: 300,
+        },
+        artists: ['Artist One'],
+        spotifyUrl: 'https://open.spotify.com/track/track-1',
+      },
+    ]);
+    assert.equal(response.body.includes('preview_url'), false);
+    assert.equal(response.body.includes('played_at'), false);
+    assert.equal(response.body.includes('api.spotify.com'), false);
+  });
+
+  await t.test('artist DTO', async () => {
+    const { handler } = loadSpotifyFunction({
+      apiResponse: jsonResponse(payloadFor('top-artists'), 200, {
+        'Cache-Control': 'public, max-age=60',
+      }),
+    });
+    const response = await handler(
+      eventFor({ resource: 'top-artists', range: 'medium_term' }),
+    );
+
+    assert.deepEqual(JSON.parse(response.body), [
+      {
+        id: 'artist-1',
+        name: 'Artist artist-1',
+        image: {
+          url: 'https://i.scdn.co/artist.jpg',
+          width: 320,
+          height: 320,
+        },
+        genres: ['indie', 'folk'],
+        spotifyUrl: 'https://open.spotify.com/artist/artist-1',
+      },
+    ]);
+  });
+
+  await t.test('playlist DTO', async () => {
+    const { handler } = loadSpotifyFunction({
+      apiResponse: jsonResponse(payloadFor('favourite-playlist'), 200, {
+        'Cache-Control': 'public, max-age=60',
+      }),
+    });
+    const response = await handler(
+      eventFor({ resource: 'favourite-playlist' }),
+    );
+
+    assert.deepEqual(JSON.parse(response.body), {
+      id: '3qWhbV6ul3Bfl2iHrN4TYn',
+      name: 'Playlist 3qWhbV6ul3Bfl2iHrN4TYn',
+      image: {
+        url: 'https://mosaic.scdn.co/medium.jpg',
+        width: 300,
+        height: 300,
+      },
+      ownerName: 'Ayush',
+      trackCount: 42,
+      spotifyUrl: 'https://open.spotify.com/playlist/3qWhbV6ul3Bfl2iHrN4TYn',
+    });
+  });
+});
+
+test('never returns more than the fixed ten-item collection slice', async () => {
+  const { handler } = loadSpotifyFunction({
+    apiResponse: jsonResponse(
+      {
+        items: Array.from({ length: 12 }, (_, index) =>
+          spotifyTrack(`${index}`),
+        ),
+      },
+      200,
+      { 'Cache-Control': 'public, max-age=60' },
+    ),
+  });
+  const response = await handler(
+    eventFor({ resource: 'top-tracks', range: 'short_term' }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(JSON.parse(response.body).length, 10);
+});
+
+test('preserves genuine empty states and rejects malformed upstream data', async () => {
+  const emptyNowPlaying = loadSpotifyFunction({
+    apiResponse: jsonResponse(null, 204, {
+      'Cache-Control': 'public, max-age=30',
+    }),
+  });
+  const emptyNowPlayingResponse = await emptyNowPlaying.handler(
+    eventFor({ resource: 'now-playing' }),
+  );
+  assert.equal(emptyNowPlayingResponse.statusCode, 204);
+  assert.equal('body' in emptyNowPlayingResponse, false);
+
+  const emptyCollection = loadSpotifyFunction({
+    apiResponse: jsonResponse({ items: [] }, 200, {
+      'Cache-Control': 'public, max-age=300',
+    }),
+  });
+  const emptyCollectionResponse = await emptyCollection.handler(
+    eventFor({ resource: 'saved-tracks' }),
+  );
+  assert.equal(emptyCollectionResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(emptyCollectionResponse.body), []);
+
+  const malformed = loadSpotifyFunction({
+    apiResponse: jsonResponse({ items: [{ name: 'missing track wrapper' }] }),
+  });
+  const malformedResponse = await malformed.handler(
+    eventFor({ resource: 'saved-tracks' }),
+  );
+  assert.equal(malformedResponse.statusCode, 502);
+  assert.deepEqual(JSON.parse(malformedResponse.body), {
+    error: 'upstream_failure',
+  });
+  assert.equal(malformedResponse.headers['Cache-Control'], 'no-store');
+});
+
+test('classifies Spotify rate limits and sanitizes Retry-After', async () => {
+  for (const [retryAfter, expected] of [
+    ['17', '17'],
+    ['0', undefined],
+    ['1.5', undefined],
+    ['soon', undefined],
+    ['9007199254740992', undefined],
+  ]) {
+    const { handler } = loadSpotifyFunction({
+      apiResponse: jsonResponse(
+        { error: { status: 429, message: 'upstream detail' } },
+        429,
+        { 'Retry-After': retryAfter },
+      ),
+    });
+    const response = await handler(eventFor({ resource: 'now-playing' }));
+
+    assert.equal(response.statusCode, 429, retryAfter);
+    assert.deepEqual(JSON.parse(response.body), { error: 'rate_limited' });
+    assert.equal(response.headers['Retry-After'], expected, retryAfter);
+    assert.equal(response.headers['Cache-Control'], 'no-store');
+    assert.equal(response.body.includes('upstream detail'), false);
+  }
+});
+
+test('classifies token-endpoint rate limits without retrying', async () => {
+  const { handler, calls } = loadSpotifyFunction({
+    tokenResponse: jsonResponse({ error: 'rate_limited' }, 429, {
+      'Retry-After': '23',
+    }),
+  });
+  const response = await handler(eventFor({ resource: 'now-playing' }));
+
+  assert.equal(response.statusCode, 429);
+  assert.deepEqual(JSON.parse(response.body), { error: 'rate_limited' });
+  assert.equal(response.headers['Retry-After'], '23');
+  assert.equal(calls.length, 1);
+});
+
+test('uses the stricter Spotify or application cache lifetime and never stale-serves', async () => {
+  const cases = [
+    ['now-playing', 'public, max-age=120', 'public, max-age=30'],
+    ['saved-tracks', 'public, max-age=120', 'public, max-age=120'],
+    ['saved-tracks', 'public, max-age=900', 'public, max-age=300'],
+    ['saved-tracks', 'public, max-age=300, s-maxage=45', 'public, max-age=45'],
+    ['saved-tracks', 'private, max-age=300', 'no-store'],
+    ['saved-tracks', 'no-cache, max-age=300', 'no-store'],
+    ['saved-tracks', 'no-store', 'no-store'],
+    ['saved-tracks', undefined, 'no-store'],
+  ];
+
+  for (const [resource, cacheControl, expected] of cases) {
+    const headers = cacheControl ? { 'Cache-Control': cacheControl } : {};
+    const { handler } = loadSpotifyFunction({
+      apiResponse: jsonResponse(payloadFor(resource), 200, headers),
+    });
+    const query = resource === 'now-playing' ? { resource } : { resource };
+    const response = await handler(eventFor(query));
+
+    assert.equal(response.statusCode, 200, `${resource}: ${cacheControl}`);
+    assert.equal(response.headers['Cache-Control'], expected);
+    if (expected === 'no-store') {
+      assert.equal(response.headers['Netlify-CDN-Cache-Control'], undefined);
+    } else {
+      assert.equal(
+        response.headers['Netlify-CDN-Cache-Control'],
+        expected.replace('public, ', 'public, durable, '),
+      );
+      assert.equal(
+        response.headers['Netlify-CDN-Cache-Control'].includes(
+          'stale-while-revalidate',
+        ),
+        false,
+      );
+    }
+  }
+});
+
+test('reports a safe reauthorization error when Spotify revokes the refresh token', async () => {
+  const { handler } = loadSpotifyFunction({
+    tokenResponse: jsonResponse({ error: 'invalid_grant' }, 400),
+  });
+  const response = await handler(
+    eventFor({ resource: 'top-tracks', range: 'short_term' }),
+  );
 
   assert.equal(response.statusCode, 503);
   assert.deepEqual(JSON.parse(response.body), {
     error: 'reauthorization_required',
   });
+  assert.equal(response.headers['Cache-Control'], 'no-store');
 });
 
-test('keeps other token failures generic', async () => {
-  const handler = loadHandler({ error: 'invalid_client' });
-
-  const response = await handler({
-    httpMethod: 'GET',
-    queryStringParameters: { path: '/me/top/tracks' },
+test('keeps other token and Spotify API failures generic and non-cacheable', async () => {
+  const tokenFailure = loadSpotifyFunction({
+    tokenResponse: jsonResponse({ error: 'invalid_client' }, 400),
+  });
+  const tokenResponse = await tokenFailure.handler(
+    eventFor({ resource: 'top-tracks', range: 'short_term' }),
+  );
+  assert.equal(tokenResponse.statusCode, 502);
+  assert.deepEqual(JSON.parse(tokenResponse.body), {
+    error: 'upstream_failure',
   });
 
-  assert.equal(response.statusCode, 502);
-  assert.deepEqual(JSON.parse(response.body), {
-    error: 'Failed to proxy Spotify request',
+  const apiFailure = loadSpotifyFunction({
+    apiResponse: jsonResponse({ private: 'detail' }, 500),
   });
+  const apiResponse = await apiFailure.handler(
+    eventFor({ resource: 'now-playing' }),
+  );
+  assert.equal(apiResponse.statusCode, 502);
+  assert.deepEqual(JSON.parse(apiResponse.body), {
+    error: 'upstream_failure',
+  });
+  assert.equal(apiResponse.headers['Cache-Control'], 'no-store');
+});
+
+test('uses a replacement refresh token during the lifetime of a warm function', async () => {
+  const refreshBodies = [];
+  const { handler, calls } = loadSpotifyFunction({
+    tokenResponse: (requestNumber) =>
+      requestNumber === 1
+        ? jsonResponse({
+            access_token: 'first-access-token',
+            expires_in: 1,
+            refresh_token: 'replacement-refresh-token',
+          })
+        : jsonResponse({
+            access_token: 'second-access-token',
+            expires_in: 3600,
+          }),
+    apiResponse: (_url, options) => {
+      refreshBodies.push(options.headers.Authorization);
+      return jsonResponse(payloadFor('now-playing'), 200, {
+        'Cache-Control': 'no-store',
+      });
+    },
+  });
+
+  await handler(eventFor({ resource: 'now-playing' }));
+  await handler(eventFor({ resource: 'saved-tracks' }));
+
+  const tokenCalls = calls.filter((call) => call.url.includes('/api/token'));
+  assert.equal(tokenCalls.length, 2);
+  assert.equal(
+    new URLSearchParams(tokenCalls[1].options.body).get('refresh_token'),
+    'replacement-refresh-token',
+  );
+  assert.deepEqual(refreshBodies, [
+    'Bearer first-access-token',
+    'Bearer second-access-token',
+  ]);
 });


### PR DESCRIPTION
## Summary

- replace the arbitrary Spotify `path=` proxy with a fixed, least-privilege presentation API at `/api/spotify`
- return minimal track, artist, and playlist DTOs; remove deprecated preview audio and player controls
- require a dual-slot Cloudflare-to-Netlify origin key in deployed contexts and add a native 30 requests / 60 seconds Netlify backstop
- honor Spotify cache policy and `Retry-After`, preserve safe authorization diagnostics, and keep visitor-facing availability states distinct
- migrate all clients and the production health check to fixed resource keys
- add a Spotify-specific privacy notice and a Cloudflare/DNS cutover, rotation, verification, and rollback runbook

## Merge gate — do not merge yet

This PR intentionally fails closed outside local development. **Do not merge until every pre-merge checkbox in `docs/spotify-security-runbook.md` is complete**, especially:

- Cloudflare is authoritative and Full (strict) TLS is healthy
- the exact-path header transform, GET-only WAF rule, 12/10 burst limit, and cache bypass are active for `/api/spotify`
- the same independent 256-bit origin key is stored as `SPOTIFY_ORIGIN_KEY_CURRENT` in Netlify Production only
- `SPOTIFY_LOCAL_DEV_BYPASS` is absent from every deployed Netlify context
- the current production music UI and health workflow remain healthy through Cloudflare

Deploy previews intentionally cannot reach Spotify after this change.

## Verification

- `npm test` — 35 tests pass
- `npm run check` — pass (one pre-existing `document.execCommand` deprecation hint)
- `npm run lint` — pass
- `npm run build` — pass
- changed-file Prettier check — pass
- `git diff --check` — pass
- changed-scope React Doctor — no issues
- packaged Netlify function manifest — runtime v2, exact `/api/spotify` route, and 30/60 IP+domain sliding-window rule present
- local Netlify emulator — all seven fixed resources returned their expected DTO/empty response with real Spotify credentials

## Operational notes

Netlify's local Astro emulator does not expose a deploy-context marker. The repository's dev script therefore supplies a process-only `SPOTIFY_LOCAL_DEV_BYPASS=true`; an explicit deployed Netlify context takes precedence and cannot use that bypass. Never configure this variable in Netlify.

Spotify's current upstream responses were `no-store` during local verification, so the proxy correctly disabled both shared and browser caching for those responses rather than inventing freshness.
